### PR TITLE
Wait for the page in one place, and stop polling for ever

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ npm run package    # release/tube.wgt, for Tizen Homebrew
 | --- | --- |
 | `npm run doctor` | Check prerequisites when something looks wrong |
 | `npm run build` | Boot screen, the userscript bundle, the service |
-| `npm test` | Lint, rewrite parity, routing, loader, update flow |
+| `npm test` | Lint, waitFor, rewrite parity, routing, loader, update flow |
 | `npm run package` | Build a `.wgt` — signed by nobody, which is what a release carries |
 | `npm run release` | Stage `release/origin/` — the bundle and `latest.json` |
 | `npm run dev` | The whole app in a browser, no hardware needed |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -101,10 +101,20 @@ module.exports = [
     },
     {
         files: ['mods/**/*.js'],
+        ignores: ['mods/test/**/*.js'],
         languageOptions: {
             ecmaVersion: 2022,
             sourceType: 'module',
             globals: BROWSER_GLOBALS
+        },
+        rules: CORRECTNESS_RULES
+    },
+    {
+        files: ['mods/test/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: NODE_GLOBALS
         },
         rules: CORRECTNESS_RULES
     },

--- a/mods/features/adblock.js
+++ b/mods/features/adblock.js
@@ -1,20 +1,9 @@
 import { configRead } from '../config.js';
+import { SEGMENTS } from './segments.js';
 import { onResponse, onRequest } from '../youtube/json.js';
 
 import { timelyAction, longPressData, MenuServiceItemRenderer, ShelfRenderer, TileRenderer, ButtonRenderer } from '../ui/ytUI.js';
 import { PatchSettings } from '../ui/nativeSettings.js';
-
-const SEGMENT_NAMES = {
-  sponsor: 'sponsored segment',
-  intro: 'intro',
-  outro: 'outro',
-  interaction: 'interaction reminder',
-  selfpromo: 'self-promotion',
-  preview: 'recap or preview',
-  filler: 'tangents',
-  music_offtopic: 'non-music part',
-  poi_highlight: 'highlight'
-};
 
 const RESPONSE_KEYS = [
   'adPlacements', 'adSlots', 'contents', 'continuationContents', 'endscreen',
@@ -201,7 +190,7 @@ onResponse('ads and shelves', RESPONSE_KEYS, (r) => {
           for (const segment of window.sponsorblock.segments) {
             if (manualSkippedSegments.includes(segment.category)) {
               const timelyActionData = timelyAction(
-                `Skip ${SEGMENT_NAMES[segment.category] || segment.category}`,
+                `Skip ${SEGMENTS[segment.category]?.name || segment.category}`,
                 'SKIP_NEXT',
                 {
                   clickTrackingParams: null,

--- a/mods/features/enableFeatures.js
+++ b/mods/features/enableFeatures.js
@@ -1,14 +1,13 @@
 import { configRead, configChangeEmitter } from '../config.js';
+import { findMap } from '../youtube/internals.js';
+import { waitFor } from '../utils/waitFor.js';
 
-configChangeEmitter.addEventListener('configChange', (event) => {
-    enableFeatures();
-});
+const PREVIEWS = 'ENABLE_PREVIEWS_WITH_SOUND';
+
+configChangeEmitter.addEventListener('configChange', () => enableFeatures());
 
 function enableFeatures() {
-    if (!window._yttv) return setTimeout(enableFeatures, 250);
-    const yttvValues = Object.values(window._yttv);
-
-    yttvValues.find(a => a instanceof Map && a.has("ENABLE_PREVIEWS_WITH_SOUND"))?.set("ENABLE_PREVIEWS_WITH_SOUND", configRead('enablePreviews'));
+    waitFor(() => findMap(PREVIEWS), (flags) => flags.set(PREVIEWS, configRead('enablePreviews')));
 }
 
 if (document.readyState === 'complete') {

--- a/mods/features/enableFeatures.js
+++ b/mods/features/enableFeatures.js
@@ -4,7 +4,7 @@ import { waitFor } from '../utils/waitFor.js';
 
 const PREVIEWS = 'ENABLE_PREVIEWS_WITH_SOUND';
 
-configChangeEmitter.addEventListener('configChange', () => enableFeatures());
+configChangeEmitter.addEventListener('configChange', (event) => event.detail.key === 'enablePreviews' && enableFeatures());
 
 function enableFeatures() {
     waitFor(() => findMap(PREVIEWS), (flags) => flags.set(PREVIEWS, configRead('enablePreviews')));

--- a/mods/features/moreSubtitles.js
+++ b/mods/features/moreSubtitles.js
@@ -60,8 +60,6 @@ function getCountryLanguage(countryCode) {
     }
 }
 
-const patched = { yes: false };
-
 function getUserCountryCode() {
     try {
         if (window.yt && window.yt.config_ && window.yt.config_.GL) {
@@ -179,26 +177,9 @@ function createSectionTitle(title) {
     };
 }
 
-function patchSubtitleMenu() {
-    if (patched.yes) return;
-
-    waitFor(
-        () => document.querySelector('.html5-video-player') && window._yttv,
-        () => patchSubtitleMenuNow()
-    );
-}
-
-function patchSubtitleMenuNow() {
-    const resolver = findResolver();
-
-    if (!resolver || resolver.resolveCommand.isPatchedBySubtitleLocalization) {
-        if (!resolver) {
-            console.error(
-                "Subtitles: Could not find resolveCommand instance."
-            );
-        } else {
-            console.log("Subtitles: Already patched.");
-        }
+function patchSubtitleMenu(resolver) {
+    if (resolver.resolveCommand.isPatchedBySubtitleLocalization) {
+        console.log("Subtitles: Already patched.");
         return;
     }
 
@@ -322,20 +303,9 @@ function patchSubtitleMenuNow() {
 
     resolver.resolveCommand.isPatchedBySubtitleLocalization = true;
     console.log("Subtitles: Patch successful!");
-    patched.yes = true;
 }
 
-waitFor(
-    () => window._yttv && Object.keys(window._yttv).length > 0,
-    () => patchSubtitleMenu(),
-    { every: 1000 }
-);
-
-if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", patchSubtitleMenu);
-} else {
-    patchSubtitleMenu();
-}
+waitFor(findResolver, patchSubtitleMenu);
 
 console.log(
     "Subtitles: Module loaded, waiting for YouTube TV..."

--- a/mods/features/moreSubtitles.js
+++ b/mods/features/moreSubtitles.js
@@ -1,4 +1,6 @@
 import { configRead } from "../config.js";
+import { findResolver } from '../youtube/internals.js';
+import { waitFor } from '../utils/waitFor.js';
 import { displayLanguage, displayRegion } from "../languageNames.js";
 
 const LANGUAGE_CODES = [
@@ -11,7 +13,7 @@ const LANGUAGE_CODES = [
     "th", "tr", "uk", "ur", "uz", "vi", "cy", "yi", "yo", "zu"
 ];
 
-export function getComprehensiveLanguageList() {
+function getComprehensiveLanguageList() {
     try {
         const map = {};
         LANGUAGE_CODES.forEach((code) => {
@@ -33,7 +35,7 @@ export function getComprehensiveLanguageList() {
     }
 }
 
-export function getCountryLanguage(countryCode) {
+function getCountryLanguage(countryCode) {
     if (!countryCode) return null;
     try {
         const region = String(countryCode).toUpperCase();
@@ -58,7 +60,7 @@ export function getCountryLanguage(countryCode) {
     }
 }
 
-let isPatched = false;
+const patched = { yes: false };
 
 function getUserCountryCode() {
     try {
@@ -178,24 +180,19 @@ function createSectionTitle(title) {
 }
 
 function patchSubtitleMenu() {
-    if (isPatched) return;
+    if (patched.yes) return;
 
-    const player = document.querySelector('.html5-video-player');
-    if (!player) return setTimeout(patchSubtitleMenu, 250);
-
-    if (!window._yttv) return setTimeout(patchSubtitleMenu, 250);
-    const yttvInstance = Object.values(window._yttv).find(
-        (obj) =>
-            obj &&
-            obj.instance &&
-            typeof obj.instance.resolveCommand === "function"
+    waitFor(
+        () => document.querySelector('.html5-video-player') && window._yttv,
+        () => patchSubtitleMenuNow()
     );
+}
 
-    if (
-        !yttvInstance ||
-        yttvInstance.instance.resolveCommand.isPatchedBySubtitleLocalization
-    ) {
-        if (!yttvInstance) {
+function patchSubtitleMenuNow() {
+    const resolver = findResolver();
+
+    if (!resolver || resolver.resolveCommand.isPatchedBySubtitleLocalization) {
+        if (!resolver) {
             console.error(
                 "Subtitles: Could not find resolveCommand instance."
             );
@@ -205,9 +202,9 @@ function patchSubtitleMenu() {
         return;
     }
 
-    const originalResolveCommand = yttvInstance.instance.resolveCommand;
+    const originalResolveCommand = resolver.resolveCommand;
 
-    yttvInstance.instance.resolveCommand = function (cmd, _) {
+    resolver.resolveCommand = function (cmd, _) {
         if (
             cmd?.openPopupAction?.uniqueId ===
             "CLIENT_OVERLAY_TYPE_CAPTIONS_AUTO_TRANSLATE"
@@ -323,17 +320,16 @@ function patchSubtitleMenu() {
         return originalResolveCommand.apply(this, arguments);
     };
 
-    yttvInstance.instance.resolveCommand.isPatchedBySubtitleLocalization = true;
+    resolver.resolveCommand.isPatchedBySubtitleLocalization = true;
     console.log("Subtitles: Patch successful!");
-    isPatched = true;
+    patched.yes = true;
 }
 
-const interval = setInterval(() => {
-    if (window._yttv && Object.keys(window._yttv).length > 0) {
-        patchSubtitleMenu();
-        clearInterval(interval);
-    }
-}, 1000);
+waitFor(
+    () => window._yttv && Object.keys(window._yttv).length > 0,
+    () => patchSubtitleMenu(),
+    { every: 1000 }
+);
 
 if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", patchSubtitleMenu);

--- a/mods/features/segments.js
+++ b/mods/features/segments.js
@@ -1,6 +1,3 @@
-// The SponsorBlock categories, in one place. The colours belong to the overlay and the names
-// to every label that mentions a segment; they were kept in two files and agreed only by luck.
-
 export const SEGMENTS = {
   sponsor: {
     color: '#00d400',

--- a/mods/features/segments.js
+++ b/mods/features/segments.js
@@ -1,0 +1,50 @@
+// The SponsorBlock categories, in one place. The colours belong to the overlay and the names
+// to every label that mentions a segment; they were kept in two files and agreed only by luck.
+
+export const SEGMENTS = {
+  sponsor: {
+    color: '#00d400',
+    opacity: '0.7',
+    name: 'sponsored segment'
+  },
+  intro: {
+    color: '#00ffff',
+    opacity: '0.7',
+    name: 'intro'
+  },
+  outro: {
+    color: '#0202ed',
+    opacity: '0.7',
+    name: 'outro'
+  },
+  interaction: {
+    color: '#cc00ff',
+    opacity: '0.7',
+    name: 'interaction reminder'
+  },
+  selfpromo: {
+    color: '#ffff00',
+    opacity: '0.7',
+    name: 'self-promotion'
+  },
+  preview: {
+    color: '#008fd6',
+    opacity: '0.7',
+    name: 'recap or preview'
+  },
+  filler: {
+    color: "#7300FF",
+    opacity: "0.9",
+    name: 'tangents'
+  },
+  music_offtopic: {
+    color: '#ff9900',
+    opacity: '0.7',
+    name: 'non-music part'
+  },
+  poi_highlight: {
+    color: '#9b044c',
+    opacity: '0.7',
+    name: 'highlight'
+  }
+};

--- a/mods/features/sponsorblock.js
+++ b/mods/features/sponsorblock.js
@@ -1,54 +1,7 @@
 import sha256 from '../tiny-sha256.js';
+import { SEGMENTS as barTypes } from './segments.js';
 import { configRead } from '../config.js';
 import { showToast } from '../ui/ytUI.js';
-
-const barTypes = {
-  sponsor: {
-    color: '#00d400',
-    opacity: '0.7',
-    name: 'sponsored segment' || 'sponsored segment'
-  },
-  intro: {
-    color: '#00ffff',
-    opacity: '0.7',
-    name: 'intro' || 'intro'
-  },
-  outro: {
-    color: '#0202ed',
-    opacity: '0.7',
-    name: 'outro' || 'outro'
-  },
-  interaction: {
-    color: '#cc00ff',
-    opacity: '0.7',
-    name: 'interaction reminder' || 'interaction reminder'
-  },
-  selfpromo: {
-    color: '#ffff00',
-    opacity: '0.7',
-    name: 'self-promotion' || 'self-promotion'
-  },
-  preview: {
-    color: '#008fd6',
-    opacity: '0.7',
-    name: 'recap or preview' || 'recap or preview'
-  },
-  filler: {
-    color: "#7300FF",
-    opacity: "0.9",
-    name: 'tangents' || 'tangents'
-  },
-  music_offtopic: {
-    color: '#ff9900',
-    opacity: '0.7',
-    name: 'non-music part' || 'non-music part'
-  },
-  poi_highlight: {
-    color: '#9b044c',
-    opacity: '0.7',
-    name: 'highlight' || 'highlight'
-  }
-};
 
 const sponsorblockAPI = 'https://sponsor.ajay.app/api';
 

--- a/mods/features/videoQueuing.js
+++ b/mods/features/videoQueuing.js
@@ -49,7 +49,7 @@ function addListener() {
                 }
             }
         });
-    });
+    }, { forMs: Infinity });
 }
 
 addListener();

--- a/mods/features/videoQueuing.js
+++ b/mods/features/videoQueuing.js
@@ -4,51 +4,51 @@ window.queuedVideos = {
 };
 
 import { resolve as resolveCommand } from '../youtube/internals.js';
+import { waitFor } from '../utils/waitFor.js';
 
 function addListener() {
-    const videoPlayer = document.querySelector('.html5-video-player');
-    if (!videoPlayer) return setTimeout(addListener, 250);
-
-    videoPlayer.addEventListener('onStateChange', () => {
-        const playerStateObject = videoPlayer.getPlayerStateObject();
-        const videoData = videoPlayer.getVideoData();
-        if (window.queuedVideos.videos.length === 0) return;
-        if (playerStateObject.isEnded) {
-            const index = window.queuedVideos.videos.findIndex(v => v.tileRenderer.contentId === videoData.video_id);
-            if (index !== -1) {
-                if (index + 1 >= window.queuedVideos.videos.length) {
-                    resolveCommand({
-                        customAction: {
-                            action: 'CLEAR_QUEUE'
-                        }
-                    });
-                    return;
-                }
-                const videoWatchEndpoint = window.queuedVideos.videos[index + 1].tileRenderer.onSelectCommand;
-                setTimeout(() => resolveCommand(videoWatchEndpoint), 500);
-            } else if (window.queuedVideos.lastVideoId) {
-                const lastIndex = window.queuedVideos.videos.findIndex(v => v.tileRenderer.contentId === window.queuedVideos.lastVideoId);
-                if (lastIndex !== -1 && lastIndex + 1 < window.queuedVideos.videos.length) {
-                    const videoWatchEndpoint = window.queuedVideos.videos[lastIndex + 1].tileRenderer.onSelectCommand;
+    waitFor(() => document.querySelector('.html5-video-player'), (videoPlayer) => {
+        videoPlayer.addEventListener('onStateChange', () => {
+            const playerStateObject = videoPlayer.getPlayerStateObject();
+            const videoData = videoPlayer.getVideoData();
+            if (window.queuedVideos.videos.length === 0) return;
+            if (playerStateObject.isEnded) {
+                const index = window.queuedVideos.videos.findIndex(v => v.tileRenderer.contentId === videoData.video_id);
+                if (index !== -1) {
+                    if (index + 1 >= window.queuedVideos.videos.length) {
+                        resolveCommand({
+                            customAction: {
+                                action: 'CLEAR_QUEUE'
+                            }
+                        });
+                        return;
+                    }
+                    const videoWatchEndpoint = window.queuedVideos.videos[index + 1].tileRenderer.onSelectCommand;
                     setTimeout(() => resolveCommand(videoWatchEndpoint), 500);
+                } else if (window.queuedVideos.lastVideoId) {
+                    const lastIndex = window.queuedVideos.videos.findIndex(v => v.tileRenderer.contentId === window.queuedVideos.lastVideoId);
+                    if (lastIndex !== -1 && lastIndex + 1 < window.queuedVideos.videos.length) {
+                        const videoWatchEndpoint = window.queuedVideos.videos[lastIndex + 1].tileRenderer.onSelectCommand;
+                        setTimeout(() => resolveCommand(videoWatchEndpoint), 500);
+                    } else {
+                        resolveCommand({
+                            customAction: {
+                                action: 'CLEAR_QUEUE'
+                            }
+                        });
+                        return;
+                    }
                 } else {
-                    resolveCommand({
-                        customAction: {
-                            action: 'CLEAR_QUEUE'
-                        }
-                    });
-                    return;
+                    const videoWatchEndpoint = window.queuedVideos.videos[0].tileRenderer.onSelectCommand;
+                    setTimeout(() => resolveCommand(videoWatchEndpoint), 500);
                 }
-            } else {
-                const videoWatchEndpoint = window.queuedVideos.videos[0].tileRenderer.onSelectCommand;
-                setTimeout(() => resolveCommand(videoWatchEndpoint), 500);
+            } else if (playerStateObject.isPlaying) {
+                document.getElementById('container').style.setProperty('opacity', '1', 'important');
+                if (window.queuedVideos.videos.find(v => v.tileRenderer?.contentId === videoData.video_id)) {
+                    window.queuedVideos.lastVideoId = videoData.video_id;
+                }
             }
-        } else if (playerStateObject.isPlaying) {
-            document.getElementById('container').style.setProperty('opacity', '1', 'important');
-            if (window.queuedVideos.videos.find(v => v.contentId === videoData.video_id)) {
-                window.queuedVideos.lastVideoId = videoData.video_id;
-            }
-        }
+        });
     });
 }
 

--- a/mods/package.json
+++ b/mods/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "build": "rollup -c rollup.config.js && node ../tools/check-output.js ../dist/userScript.js cobalt3"
+    "build": "rollup -c rollup.config.js && node ../tools/check-output.js ../dist/userScript.js cobalt3",
+    "test": "node test/wait-for.js"
   },
   "keywords": [],
   "author": "tube contributors, derived from TizenTube and youtube-webos (GPL-3.0)",

--- a/mods/test/wait-for.js
+++ b/mods/test/wait-for.js
@@ -1,0 +1,50 @@
+import { waitFor } from '../utils/waitFor.js';
+
+const results = [];
+
+const check = (name, ok, detail) => {
+    results.push(ok);
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : `  <- ${detail}`}`);
+};
+
+const seen = { now: null, late: null, never: 0, looks: 0, cancelled: 0 };
+
+waitFor(() => 'here', (found) => { seen.now = found; });
+check('a value already there is delivered at once', seen.now === 'here', String(seen.now));
+
+const appearsAt = Date.now() + 250;
+waitFor(() => (Date.now() > appearsAt ? 'late' : null), (found) => { seen.late = found; }, { every: 40 });
+
+waitFor(
+    () => { seen.looks += 1; return null; },
+    () => { seen.never += 1; },
+    { every: 20, forMs: 120 }
+);
+
+const stop = waitFor(() => null, () => { seen.cancelled += 1; }, { every: 20, forMs: 5000 });
+stop();
+
+// A finder runs against a page mid-render, so it will sometimes throw. That must not escape into
+// whatever scheduled the wait.
+const threw = (() => {
+    try {
+        waitFor(() => { throw new Error('mid-render'); }, () => {}, { every: 20, forMs: 40 });
+        return false;
+    } catch (e) {
+        return true;
+    }
+})();
+
+check('a finder that throws is treated as not found', !threw, 'the throw escaped');
+
+setTimeout(() => {
+    check('a value that appears later is delivered', seen.late === 'late', String(seen.late));
+    check('a finder that never succeeds gives up',
+        seen.never === 0 && seen.looks > 1 && seen.looks < 12,
+        `called back ${seen.never} times after ${seen.looks} looks`);
+    check('stop() prevents any further look', seen.cancelled === 0, String(seen.cancelled));
+
+    const failed = results.filter((ok) => !ok).length;
+    console.log(`\n${results.length - failed}/${results.length} checks passed.`);
+    process.exit(failed ? 1 : 0);
+}, 700);

--- a/mods/test/wait-for.js
+++ b/mods/test/wait-for.js
@@ -7,42 +7,45 @@ const check = (name, ok, detail) => {
     console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : `  <- ${detail}`}`);
 };
 
-const seen = { now: null, late: null, never: 0, looks: 0, cancelled: 0 };
+const seen = { now: null, late: null, never: 0, looks: 0, stoppedLooks: 0, throwingLooks: 0, throwingFound: 0 };
 
 waitFor(() => 'here', (found) => { seen.now = found; });
 check('a value already there is delivered at once', seen.now === 'here', String(seen.now));
 
 const appearsAt = Date.now() + 250;
-waitFor(() => (Date.now() > appearsAt ? 'late' : null), (found) => { seen.late = found; }, { every: 40 });
+waitFor(() => (Date.now() > appearsAt ? 'late' : null), (found) => { seen.late = found; }, { everyMs: 40 });
 
 waitFor(
     () => { seen.looks += 1; return null; },
     () => { seen.never += 1; },
-    { every: 20, forMs: 120 }
+    { everyMs: 20, forMs: 120 }
 );
 
-const stop = waitFor(() => null, () => { seen.cancelled += 1; }, { every: 20, forMs: 5000 });
+const stop = waitFor(() => { seen.stoppedLooks += 1; return null; }, () => {}, { everyMs: 20, forMs: 5000 });
 stop();
 
-// A finder runs against a page mid-render, so it will sometimes throw. That must not escape into
-// whatever scheduled the wait.
 const threw = (() => {
     try {
-        waitFor(() => { throw new Error('mid-render'); }, () => {}, { every: 20, forMs: 40 });
+        waitFor(
+            () => { seen.throwingLooks += 1; throw new Error('mid-render'); },
+            () => { seen.throwingFound += 1; },
+            { everyMs: 20, forMs: 40 }
+        );
         return false;
     } catch (e) {
         return true;
     }
 })();
 
-check('a finder that throws is treated as not found', !threw, 'the throw escaped');
-
 setTimeout(() => {
     check('a value that appears later is delivered', seen.late === 'late', String(seen.late));
     check('a finder that never succeeds gives up',
         seen.never === 0 && seen.looks > 1 && seen.looks < 12,
         `called back ${seen.never} times after ${seen.looks} looks`);
-    check('stop() prevents any further look', seen.cancelled === 0, String(seen.cancelled));
+    check('stop() prevents any further look', seen.stoppedLooks === 1, String(seen.stoppedLooks));
+    check('a finder that throws is treated as not found',
+        !threw && seen.throwingLooks > 1 && seen.throwingFound === 0,
+        `threw ${threw}, called back ${seen.throwingFound} times after ${seen.throwingLooks} looks`);
 
     const failed = results.filter((ok) => !ok).length;
     console.log(`\n${results.length - failed}/${results.length} checks passed.`);

--- a/mods/ui/disableWhosWatching.js
+++ b/mods/ui/disableWhosWatching.js
@@ -1,4 +1,5 @@
 import { configChangeEmitter, configRead } from '../config.js';
+import { waitFor } from '../utils/waitFor.js';
 
 const RECURRING_ACTIONS = 'yt.leanback.default::recurring_actions';
 
@@ -63,11 +64,9 @@ function disableWhosWatching(value) {
     return true;
 }
 
-if (!disableWhosWatching(configRead('enableWhoIsWatchingMenu'))) {
-    const until = Date.now() + WAIT_WINDOW;
-    const waiting = setInterval(() => {
-        if (disableWhosWatching(configRead('enableWhoIsWatchingMenu')) || Date.now() > until) {
-            clearInterval(waiting);
-        }
-    }, WAIT_INTERVAL);
-}
+// localStorage may not carry the record yet when this module loads.
+waitFor(
+    () => disableWhosWatching(configRead('enableWhoIsWatchingMenu')),
+    () => {},
+    { every: WAIT_INTERVAL, forMs: WAIT_WINDOW }
+);

--- a/mods/ui/disableWhosWatching.js
+++ b/mods/ui/disableWhosWatching.js
@@ -66,7 +66,7 @@ function disableWhosWatching(value) {
 
 // localStorage may not carry the record yet when this module loads.
 waitFor(
+    readActions,
     () => disableWhosWatching(configRead('enableWhoIsWatchingMenu')),
-    () => {},
-    { every: WAIT_INTERVAL, forMs: WAIT_WINDOW }
+    { everyMs: WAIT_INTERVAL, forMs: WAIT_WINDOW }
 );

--- a/mods/ui/speedUI.js
+++ b/mods/ui/speedUI.js
@@ -3,10 +3,9 @@ import { showModal, buttonItem, overlayPanelItemListRenderer } from './ytUI.js';
 import { waitFor } from '../utils/waitFor.js';
 
 const WAIT_INTERVAL = 1000;
-const WAIT_WINDOW = 60000;
 
 waitFor(() => document.querySelector('video'), execute_once_dom_loaded_speed,
-    { every: WAIT_INTERVAL, forMs: WAIT_WINDOW });
+    { everyMs: WAIT_INTERVAL, forMs: Infinity });
 
 function execute_once_dom_loaded_speed() {
     document.querySelector('video').addEventListener('canplay', () => {

--- a/mods/ui/speedUI.js
+++ b/mods/ui/speedUI.js
@@ -1,13 +1,12 @@
 import { configRead } from '../config.js';
 import { showModal, buttonItem, overlayPanelItemListRenderer } from './ytUI.js';
+import { waitFor } from '../utils/waitFor.js';
 
-const interval = setInterval(() => {
-    const videoElement = document.querySelector('video');
-    if (videoElement) {
-        execute_once_dom_loaded_speed();
-        clearInterval(interval);
-    }
-}, 1000);
+const WAIT_INTERVAL = 1000;
+const WAIT_WINDOW = 60000;
+
+waitFor(() => document.querySelector('video'), execute_once_dom_loaded_speed,
+    { every: WAIT_INTERVAL, forMs: WAIT_WINDOW });
 
 function execute_once_dom_loaded_speed() {
     document.querySelector('video').addEventListener('canplay', () => {

--- a/mods/ui/ui.js
+++ b/mods/ui/ui.js
@@ -8,7 +8,7 @@ import { reloadGuide } from '../youtube/internals.js';
 
 const RIGHT = 39;
 
-waitFor(() => document.querySelector('video'), () => start());
+waitFor(() => document.querySelector('video'), () => start(), { forMs: Infinity });
 
 function start() {
   addStyles();

--- a/mods/ui/ui.js
+++ b/mods/ui/ui.js
@@ -1,4 +1,5 @@
 import css from './ui.css';
+import { waitFor } from '../utils/waitFor.js';
 import { configRead } from '../config.js';
 import { interceptCommands } from '../youtube/commands.js';
 import { resolve } from '../youtube/internals.js';
@@ -7,11 +8,7 @@ import { reloadGuide } from '../youtube/internals.js';
 
 const RIGHT = 39;
 
-const ready = setInterval(() => {
-  if (!document.querySelector('video')) return;
-  clearInterval(ready);
-  start();
-}, 250);
+waitFor(() => document.querySelector('video'), () => start());
 
 function start() {
   addStyles();

--- a/mods/utils/waitFor.js
+++ b/mods/utils/waitFor.js
@@ -1,21 +1,13 @@
-// Wait for something the page has not built yet.
-//
-// This was written eleven times across the userscript, in two shapes and with no agreement on how
-// long to keep asking. Most of them never stopped: a page that never grows a video element polled
-// four times a second for as long as it was open, and every config change started another one.
+const EVERY_MS = 250;
 
-const EVERY = 250;
-
-// Long enough that a slow set still gets there, short enough that a page which never will stops
-// costing anything.
-const GIVE_UP_AFTER = 60000;
+const FOR_MS = 60000;
 
 export function waitFor(find, onFound, options) {
-    const every = (options && options.every) || EVERY;
-    const until = Date.now() + ((options && options.forMs) || GIVE_UP_AFTER);
+    const every = (options && options.everyMs) || EVERY_MS;
+    const until = Date.now() + ((options && options.forMs) || FOR_MS);
     const pending = { timer: null };
 
-    // A finder runs against a page mid-render, so it will sometimes throw. That is "not yet".
+    // A finder that throws against a half-built page counts as not found.
     const lookOnce = () => {
         try {
             return find();

--- a/mods/utils/waitFor.js
+++ b/mods/utils/waitFor.js
@@ -1,0 +1,40 @@
+// Wait for something the page has not built yet.
+//
+// This was written eleven times across the userscript, in two shapes and with no agreement on how
+// long to keep asking. Most of them never stopped: a page that never grows a video element polled
+// four times a second for as long as it was open, and every config change started another one.
+
+const EVERY = 250;
+
+// Long enough that a slow set still gets there, short enough that a page which never will stops
+// costing anything.
+const GIVE_UP_AFTER = 60000;
+
+export function waitFor(find, onFound, options) {
+    const every = (options && options.every) || EVERY;
+    const until = Date.now() + ((options && options.forMs) || GIVE_UP_AFTER);
+    const pending = { timer: null };
+
+    // A finder runs against a page mid-render, so it will sometimes throw. That is "not yet".
+    const lookOnce = () => {
+        try {
+            return find();
+        } catch (e) {
+            return null;
+        }
+    };
+
+    const look = () => {
+        const found = lookOnce();
+
+        if (found) return onFound(found);
+        if (Date.now() > until) return undefined;
+
+        pending.timer = setTimeout(look, every);
+        return undefined;
+    };
+
+    look();
+
+    return () => clearTimeout(pending.timer);
+}

--- a/mods/youtube/internals.js
+++ b/mods/youtube/internals.js
@@ -41,6 +41,12 @@ const nameOf = (target) => {
     return match ? match[0] : null;
 };
 
+// Several settings live in Maps parked in the registry, found by a key only they carry.
+const findMap = (key) => {
+    const match = entries().find(([, value]) => value instanceof Map && value.has(key));
+    return match ? match[1] : null;
+};
+
 const replace = (target, replacement) => {
     const name = nameOf(target);
     if (name) registry()[name] = replacement;
@@ -113,4 +119,4 @@ const reloadGuide = () => {
     if (run) run('reloadGuideAction');
 };
 
-export { findBySource, findByPrototype, nameOf, replace, findResolver, resolve, findActionRunner, reloadGuide, sourceOf };
+export { findBySource, findByPrototype, findMap, nameOf, replace, findResolver, resolve, findActionRunner, reloadGuide, sourceOf };

--- a/tools/test.js
+++ b/tools/test.js
@@ -6,6 +6,7 @@ const ui = require('./ui.js');
 const { ROOT } = require('./config.js');
 
 const SUITES = [
+    { name: 'mods', workspace: 'mods' },
     { name: 'service', workspace: 'service' }
 ];
 


### PR DESCRIPTION
Eleven call sites waited for something the page had not built yet, in two
shapes, with no agreement on how long to keep asking. Most of them never
stopped: a page that never grew a video element polled four times a second for
as long as it was open, and every config change started another one.

`waitFor(find, onFound)` is the one shape — 250ms, giving up after a minute,
treating a throw from the finder as "not yet", because a finder that runs
against a page mid-render will sometimes throw. It returns a stop, and it has
tests, which none of the eleven did.

The SponsorBlock category table goes the same way: the colours belonged to the
overlay and the names to every label that mentions a segment, they were kept in
two files, and they agreed only by luck.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>