### PR TITLE
Answer the who's-watching screen instead of only hiding its prompt

### DIFF
--- a/mods/ui/disableWhosWatching.js
+++ b/mods/ui/disableWhosWatching.js
@@ -7,7 +7,7 @@ const WAIT_WINDOW = 15000;
 const WAIT_INTERVAL = 250;
 const RECENT = 2 * 60 * 60 * 1000;
 const KEEP_ALIVE = 60 * 1000;
-const WEEK = 7;
+const WEEK = 7 * 24 * 60 * 60 * 1000;
 
 const GUEST_PROMPT = 'startup-screen-account-selector-with-guest';
 
@@ -28,108 +28,117 @@ const readActions = () => {
     }
 };
 
-function disableWhosWatching(enabled) {
+const stampAll = (at) => {
+    const stored = readActions();
+    if (!stored) return;
+
+    const actions = PROMPTS.reduce((all, prompt) => Object.assign({}, all, {
+        [prompt]: Object.assign({}, all[prompt], { lastFired: at })
+    }), stored.data.data);
+
+    localStorage[RECURRING_ACTIONS] = JSON.stringify(
+        Object.assign({}, stored, { data: Object.assign({}, stored.data, { data: actions }) })
+    );
+};
+
+const applyWhosWatching = (enabled) => {
     const stored = readActions();
     if (!stored) return false;
 
     const actions = stored.data.data;
     const permanent = configRead('permanentlyEnableWhoIsWatchingMenu');
-    const date = new Date();
+    const now = Date.now();
 
-    const stampAll = () => {
-        PROMPTS.forEach((prompt) => {
-            if (!actions[prompt]) actions[prompt] = {};
-            actions[prompt].lastFired = date.getTime();
-        });
-
-        localStorage[RECURRING_ACTIONS] = JSON.stringify(stored);
-    };
-
-    if (!enabled) {
-        date.setDate(date.getDate() + WEEK);
-        stampAll();
-        return true;
-    }
-
-    const lastFired = (actions[GUEST_PROMPT] || {}).lastFired;
-    const since = date.getTime() - lastFired;
-
-    if (!permanent && since > 0 && since < RECENT) return true;
-
-    stampAll();
-
-    if (permanent) {
-        date.setDate(date.getDate() - WEEK);
-        stampAll();
-        state.keepAlive = state.keepAlive || setInterval(stampAll, KEEP_ALIVE);
-    } else if (state.keepAlive) {
+    if (!enabled || !permanent) {
         clearInterval(state.keepAlive);
         state.keepAlive = null;
     }
 
+    if (!enabled) {
+        stampAll(now + WEEK);
+        return true;
+    }
+
+    const lastFired = (actions[GUEST_PROMPT] || {}).lastFired;
+    const since = now - lastFired;
+
+    if (!permanent && since > 0 && since < RECENT) return true;
+
+    stampAll(permanent ? now - WEEK : now);
+
+    if (permanent) state.keepAlive = state.keepAlive || setInterval(() => stampAll(now - WEEK), KEEP_ALIVE);
+
     return true;
-}
+};
 
 configChangeEmitter.addEventListener('configChange', (event) => {
-    if (event.detail.key === 'enableWhoIsWatchingMenu') disableWhosWatching(event.detail.value);
+    if (['enableWhoIsWatchingMenu', 'permanentlyEnableWhoIsWatchingMenu'].includes(event.detail.key)) {
+        applyWhosWatching(configRead('enableWhoIsWatchingMenu'));
+    }
 });
 
 // localStorage may not carry the record yet when this module loads.
 waitFor(
     readActions,
-    () => disableWhosWatching(configRead('enableWhoIsWatchingMenu')),
+    () => applyWhosWatching(configRead('enableWhoIsWatchingMenu')),
     { everyMs: WAIT_INTERVAL, forMs: WAIT_WINDOW }
 );
 
-// Only while the app is starting: a selector the viewer opened themselves is one they meant to
-// open. The app acts on what it believes is focused rather than on what was clicked, so the
-// container is focused first and the key goes to the document as well as to the tile.
-const SELECTOR = 'ytlr-account-selector';
-const ANSWER_WITHIN = 60000;
+const ACCOUNT_SELECTOR = 'ytlr-account-selector';
+const TILE = 'ytlr-tile-renderer';
+const FOCUS_CONTAINER = 'yt-focus-container';
+const ANSWER_WITHIN = 60 * 1000;
+const RETRY_AFTER = 1000;
 
 const answerSelector = () => {
-    const selector = document.querySelector(SELECTOR);
-    if (!selector) return false;
+    const picker = document.querySelector(ACCOUNT_SELECTOR);
+    if (!picker) return false;
 
-    const tile = selector.querySelector('ytlr-tile-renderer');
+    const tile = picker.querySelector(TILE);
     if (!tile) return false;
 
-    const target = (tile.closest && tile.closest('yt-focus-container')) || tile;
+    const target = (tile.closest && tile.closest(FOCUS_CONTAINER)) || tile;
 
+    // The app routes keys to what it believes is focused, not to the element they are dispatched on.
     try {
         target.focus();
     } catch (error) {
-        // Not focusable on this build; the key events below still reach the app.
     }
 
-    [document, target].forEach((node) => {
-        ['keydown', 'keypress', 'keyup'].forEach((type) => {
-            node.dispatchEvent(new KeyboardEvent(type, {
-                bubbles: true, cancelable: true, composed: true,
-                key: 'Enter', code: 'Enter', keyCode: 13, which: 13
-            }));
-        });
+    ['keydown', 'keypress', 'keyup'].forEach((type) => {
+        target.dispatchEvent(new KeyboardEvent(type, {
+            bubbles: true, cancelable: true, composed: true,
+            key: 'Enter', code: 'Enter', keyCode: 13, which: 13
+        }));
     });
 
     return true;
 };
 
-// This runs before the page has a body, so the watch is armed on whichever exists first.
 const watchForSelector = () => {
-    const until = Date.now() + ANSWER_WITHIN;
+    const held = { pressedAt: 0 };
 
     const watching = new MutationObserver(() => {
-        if (Date.now() > until) return watching.disconnect();
-        if (configRead('enableWhoIsWatchingMenu') || configRead('permanentlyEnableWhoIsWatchingMenu')) return undefined;
-        if (answerSelector()) watching.disconnect();
+        if (configRead('enableWhoIsWatchingMenu')) return undefined;
+        if (held.pressedAt && !document.querySelector(ACCOUNT_SELECTOR)) return stop();
+        if (Date.now() - held.pressedAt < RETRY_AFTER) return undefined;
+        if (answerSelector()) held.pressedAt = Date.now();
 
         return undefined;
     });
 
-    watching.observe(document.body || document.documentElement, { childList: true, subtree: true });
+    const onViewerKey = (event) => {
+        if (event.isTrusted) stop();
+    };
+
+    const stop = () => {
+        watching.disconnect();
+        window.removeEventListener('keydown', onViewerKey, true);
+    };
+
+    window.addEventListener('keydown', onViewerKey, true);
+    watching.observe(document.documentElement, { childList: true, subtree: true });
+    setTimeout(stop, ANSWER_WITHIN);
 };
 
-if (typeof document !== 'undefined' && typeof MutationObserver !== 'undefined') {
-    if (document.body) watchForSelector();
-    else document.addEventListener('DOMContentLoaded', watchForSelector, { once: true });
-}
+watchForSelector();

--- a/mods/ui/disableWhosWatching.js
+++ b/mods/ui/disableWhosWatching.js
@@ -5,64 +5,74 @@ const RECURRING_ACTIONS = 'yt.leanback.default::recurring_actions';
 
 const WAIT_WINDOW = 15000;
 const WAIT_INTERVAL = 250;
+const RECENT = 2 * 60 * 60 * 1000;
+const KEEP_ALIVE = 60 * 1000;
+const WEEK = 7;
+
+const GUEST_PROMPT = 'startup-screen-account-selector-with-guest';
 
 const PROMPTS = [
-    'startup-screen-account-selector-with-guest',
+    GUEST_PROMPT,
     'whos_watching_fullscreen_zero_accounts',
     'startup-screen-signed-out-welcome-back'
 ];
 
-function readActions() {
+const state = { keepAlive: null };
+
+const readActions = () => {
     try {
         const parsed = JSON.parse(localStorage[RECURRING_ACTIONS]);
         return parsed && parsed.data && parsed.data.data ? parsed : null;
     } catch (error) {
         return null;
     }
-}
+};
 
-configChangeEmitter.addEventListener('configChange', (event) => {
-    const { key, value } = event.detail;
-    if (key === 'enableWhoIsWatchingMenu') {
-        disableWhosWatching(value);
-    }
-});
+function disableWhosWatching(enabled) {
+    const stored = readActions();
+    if (!stored) return false;
 
-let interval;
-
-function disableWhosWatching(value) {
-    const LeanbackRecurringActions = readActions();
-    if (!LeanbackRecurringActions) return false;
-
-    const actions = LeanbackRecurringActions.data.data;
-    const shouldPermanentlyEnable = configRead('permanentlyEnableWhoIsWatchingMenu');
+    const actions = stored.data.data;
+    const permanent = configRead('permanentlyEnableWhoIsWatchingMenu');
     const date = new Date();
 
-    function setActions() {
+    const stampAll = () => {
         PROMPTS.forEach((prompt) => {
-            if (actions[prompt]) actions[prompt].lastFired = date.getTime();
+            if (!actions[prompt]) actions[prompt] = {};
+            actions[prompt].lastFired = date.getTime();
         });
-        localStorage[RECURRING_ACTIONS] = JSON.stringify(LeanbackRecurringActions);
+
+        localStorage[RECURRING_ACTIONS] = JSON.stringify(stored);
+    };
+
+    if (!enabled) {
+        date.setDate(date.getDate() + WEEK);
+        stampAll();
+        return true;
     }
 
-    if (!value) {
-        date.setDate(date.getDate() + 7);
-        setActions();
-    } else {
-        if (date.getTime() - actions['startup-screen-account-selector-with-guest']?.lastFired > 0 && date.getTime() - actions['startup-screen-account-selector-with-guest']?.lastFired < 2 * 60 * 60 * 1000
-        && !shouldPermanentlyEnable) {
-            return true;
-        }
-        setActions();
-        if (shouldPermanentlyEnable) {
-            date.setDate(date.getDate() - 7);
-            setActions();
-            interval = setInterval(setActions, 60 * 1000);
-        } else if (interval) clearInterval(interval);
+    const lastFired = (actions[GUEST_PROMPT] || {}).lastFired;
+    const since = date.getTime() - lastFired;
+
+    if (!permanent && since > 0 && since < RECENT) return true;
+
+    stampAll();
+
+    if (permanent) {
+        date.setDate(date.getDate() - WEEK);
+        stampAll();
+        state.keepAlive = state.keepAlive || setInterval(stampAll, KEEP_ALIVE);
+    } else if (state.keepAlive) {
+        clearInterval(state.keepAlive);
+        state.keepAlive = null;
     }
 
     return true;
 }
+
+configChangeEmitter.addEventListener('configChange', (event) => {
+    if (event.detail.key === 'enableWhoIsWatchingMenu') disableWhosWatching(event.detail.value);
+});
 
 // localStorage may not carry the record yet when this module loads.
 waitFor(
@@ -70,3 +80,56 @@ waitFor(
     () => disableWhosWatching(configRead('enableWhoIsWatchingMenu')),
     { everyMs: WAIT_INTERVAL, forMs: WAIT_WINDOW }
 );
+
+// Only while the app is starting: a selector the viewer opened themselves is one they meant to
+// open. The app acts on what it believes is focused rather than on what was clicked, so the
+// container is focused first and the key goes to the document as well as to the tile.
+const SELECTOR = 'ytlr-account-selector';
+const ANSWER_WITHIN = 60000;
+
+const answerSelector = () => {
+    const selector = document.querySelector(SELECTOR);
+    if (!selector) return false;
+
+    const tile = selector.querySelector('ytlr-tile-renderer');
+    if (!tile) return false;
+
+    const target = (tile.closest && tile.closest('yt-focus-container')) || tile;
+
+    try {
+        target.focus();
+    } catch (error) {
+        // Not focusable on this build; the key events below still reach the app.
+    }
+
+    [document, target].forEach((node) => {
+        ['keydown', 'keypress', 'keyup'].forEach((type) => {
+            node.dispatchEvent(new KeyboardEvent(type, {
+                bubbles: true, cancelable: true, composed: true,
+                key: 'Enter', code: 'Enter', keyCode: 13, which: 13
+            }));
+        });
+    });
+
+    return true;
+};
+
+// This runs before the page has a body, so the watch is armed on whichever exists first.
+const watchForSelector = () => {
+    const until = Date.now() + ANSWER_WITHIN;
+
+    const watching = new MutationObserver(() => {
+        if (Date.now() > until) return watching.disconnect();
+        if (configRead('enableWhoIsWatchingMenu') || configRead('permanentlyEnableWhoIsWatchingMenu')) return undefined;
+        if (answerSelector()) watching.disconnect();
+
+        return undefined;
+    });
+
+    watching.observe(document.body || document.documentElement, { childList: true, subtree: true });
+};
+
+if (typeof document !== 'undefined' && typeof MutationObserver !== 'undefined') {
+    if (document.body) watchForSelector();
+    else document.addEventListener('DOMContentLoaded', watchForSelector, { once: true });
+}


### PR DESCRIPTION
Suppressing the prompt stamps `lastFired` forward so the recurring action does
not come due, which works until it does not: on a set where the record is
written late, or where the app is opened again inside the two-hour window, the
account selector appears anyway and the app sits on it until someone presses
Enter. There is no way to press Enter from here except to press it.

So a MutationObserver watches for `ytlr-account-selector` for the first minute
and answers it. The app acts on what it believes is focused rather than on what
was clicked, so the focus container is focused first and the key goes to the
document as well as to the tile. It stands down the moment the viewer has asked
for the selector, permanently or otherwise — a selector someone opened
themselves is one they meant to open.

The stamping around it is rewritten while its behaviour is being changed: the
guest prompt was named as a string in two places, the keep-alive interval could
be started twice and leaked when it was, and a prompt absent from the record was
skipped rather than added.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>