### PR TITLE
Report what the decoder is really doing, and ask for a quality that exists

### DIFF
--- a/mods/config.js
+++ b/mods/config.js
@@ -32,7 +32,7 @@ const defaultConfig = {
 
   preferredVideoQuality: 'highest',
   videoPreferredCodec: 'any',
-  reportPlaybackStats: true,
+  reportPlaybackStats: false,
   videoSpeed: 1,
   rememberPlaybackSpeed: false,
   speedSettingsIncrement: 0.25,

--- a/mods/config.js
+++ b/mods/config.js
@@ -32,7 +32,9 @@ const defaultConfig = {
 
   preferredVideoQuality: 'highest',
   videoPreferredCodec: 'any',
+  reportPlaybackStats: true,
   videoSpeed: 1,
+  rememberPlaybackSpeed: false,
   speedSettingsIncrement: 0.25,
 
   enableShorts: false,

--- a/mods/core.js
+++ b/mods/core.js
@@ -7,6 +7,7 @@ import './features/sponsorblock.js';
 import './features/guide.js';
 import './features/moreSubtitles.js';
 import './features/preferredVideoQuality.js';
+import './features/playbackStats.js';
 import './features/videoQueuing.js';
 import './features/enableFeatures.js';
 import './features/pictureInPicture.js';

--- a/mods/features/playbackStats.js
+++ b/mods/features/playbackStats.js
@@ -8,23 +8,22 @@ const WINDOW = 30;
 // A longer gap is a suspended app, not playback, so it is charged to nobody.
 const MAX_GAP = 2;
 const MOST_RECENT = (WINDOW * 1000) / TICK;
+const MAX_JUMP_RATIO = 4;
 
-const DEFAULT_FPS = 60;
 const MAX_PLAUSIBLE_FPS = 200;
 const EMA = 0.3;
 
-// Looking for the panel costs a walk of the document, and a closed panel never opens by itself —
-// so a fruitless search backs off instead of repeating every two seconds for the whole video.
+// Each search walks every div, span and pre, so fruitless ones back off.
 const FIND_EVERY = 2000;
 const FIND_AT_MOST_EVERY = 30000;
 
-const PLAYER = '#movie_player, .html5-video-player';
 const MARK = 'data-tube-lost';
+const SHOWN_LOSS = 0.05;
 
 // Both sides, not their difference: shortfalls only add, so jitter would read as lost time.
 export function account(previous, current) {
-    const none = { played: 0, expected: 0, advanced: 0, reseed: false };
-    const drop = { played: 0, expected: 0, advanced: 0, reseed: true };
+    const none = { expected: 0, advanced: 0, reseed: false };
+    const drop = { expected: 0, advanced: 0, reseed: true };
 
     if (!current || current.paused || current.seeking) return drop;
     if (!previous) return none;
@@ -33,18 +32,14 @@ export function account(previous, current) {
     if (wall <= 0 || wall > MAX_GAP) return drop;
 
     const advanced = current.media - previous.media;
-    const expected = wall * (previous.rate || 1);
+    const expected = wall * (previous.speed || 1);
 
-    if (advanced < 0 || advanced > expected * 4) return drop;
+    if (advanced < 0 || advanced > expected * MAX_JUMP_RATIO) return drop;
 
-    return { played: Math.min(advanced, expected), expected, advanced, reseed: false };
+    return { expected, advanced, reseed: false };
 }
 
 export function lostBy(tally) {
-    if (!tally.recent || !tally.recent.length) {
-        return Math.max(0, (tally.expected || 0) - (tally.advanced || 0));
-    }
-
     const summed = tally.recent.reduce(
         (total, step) => ({ expected: total.expected + step.expected, advanced: total.advanced + step.advanced }),
         { expected: 0, advanced: 0 }
@@ -56,16 +51,11 @@ export function lostBy(tally) {
 const tallies = new WeakMap();
 
 const blank = () => ({
-    expected: 0,
-    advanced: 0,
     recent: [],
-    fps: DEFAULT_FPS,
-    width: -1,
-    height: -1,
     previous: null,
     watching: false,
     timer: null,
-    rate: 0,
+    decodedFps: 0,
     rateFrames: 0,
     rateAt: 0,
     node: null,
@@ -83,16 +73,7 @@ const tallyFor = (video) => {
     return made;
 };
 
-const latest = { reading: null };
-
-export const measured = () => latest.reading;
-
-// -- what the renderer says ----------------------------------------------------------------------
-
-const playerElement = () => document.querySelector(PLAYER);
-
 const measureRate = (video, tally, wall) => {
-    // The prototype's own, so a patched getVideoPlaybackQuality is not averaged into itself.
     const proto = window.HTMLVideoElement && window.HTMLVideoElement.prototype;
     const real = proto && proto.getVideoPlaybackQuality;
     const quality = real ? real.call(video) : null;
@@ -106,7 +87,7 @@ const measureRate = (video, tally, wall) => {
         const perSecond = ((frames - tally.rateFrames) * 1000) / elapsed;
 
         if (perSecond >= 0 && perSecond < MAX_PLAUSIBLE_FPS) {
-            tally.rate = tally.rate ? tally.rate * (1 - EMA) + perSecond * EMA : perSecond;
+            tally.decodedFps = tally.decodedFps ? tally.decodedFps * (1 - EMA) + perSecond * EMA : perSecond;
         }
     }
 
@@ -114,22 +95,6 @@ const measureRate = (video, tally, wall) => {
     tally.rateAt = wall;
 };
 
-const frameRate = (video, tally) => {
-    if (video.videoWidth === tally.width && video.videoHeight === tally.height) return;
-
-    tally.width = video.videoWidth;
-    tally.height = video.videoHeight;
-
-    try {
-        const found = /@(\d+(?:\.\d+)?)/.exec(playerElement().getStatsForNerds().resolution || '');
-        if (found) tally.fps = parseFloat(found[1]) || tally.fps;
-    } catch (e) { /* no panel, or a build that does not answer */ }
-};
-
-// -- the label on the stats panel ------------------------------------------------------------------
-
-// find.call over the NodeList rather than Array.from(...).find: it short-circuits and copies
-// nothing, and this walks every div, span and pre on the page.
 const framesNode = () => {
     const isTheFramesLine = (node) => !node.children.length
         && node.textContent.indexOf('dropped of') !== -1;
@@ -139,13 +104,12 @@ const framesNode = () => {
 
 const said = (tally) => {
     const lost = lostBy(tally);
-    const time = lost >= 0.05 ? `~${lost.toFixed(1)}s lost` : '~no time lost';
+    const time = lost >= SHOWN_LOSS ? `~${lost.toFixed(1)}s lost` : '~no time lost';
 
-    return tally.rate ? `@ ${tally.rate.toFixed(2)} fps · ${time}` : time;
+    return tally.decodedFps ? `@ ${tally.decodedFps.toFixed(2)} fps · ${time}` : time;
 };
 
-// The panel is re-rendered under us, so the label is found by its mark rather than remembered, and
-// any duplicate a re-render left behind is removed.
+// The panel re-renders, so the label is re-found by MARK on every tick.
 const showRate = (tally, wall) => {
     if (!tally.node || !tally.node.isConnected) {
         if (wall - tally.lookedAt < tally.lookGap) return;
@@ -184,9 +148,7 @@ const dropLabel = (tally) => {
     tally.node = null;
 };
 
-// -- sampling ---------------------------------------------------------------------------------------
-
-export function sample(video) {
+function sample(video) {
     const tally = tallyFor(video);
 
     // The player swaps elements without ending playback; a timer on a detached one keeps it alive.
@@ -199,58 +161,52 @@ export function sample(video) {
     const current = {
         wall: Date.now(),
         media: video.currentTime,
-        rate: video.playbackRate,
+        speed: video.playbackRate,
         paused: video.paused,
-        seeking: video.seeking,
-        readyState: video.readyState
+        seeking: video.seeking
     };
 
     const step = account(tally.previous, current);
 
-    tally.expected += step.expected;
-    tally.advanced += step.advanced;
-    tally.recent.push({ expected: step.expected, advanced: step.advanced });
-    tally.recent.splice(0, Math.max(0, tally.recent.length - MOST_RECENT));
+    tally.recent = tally.recent.concat([{ expected: step.expected, advanced: step.advanced }]).slice(-MOST_RECENT);
 
-    frameRate(video, tally);
     measureRate(video, tally, current.wall);
     showRate(tally, current.wall);
-
-    latest.reading = {
-        lost: +lostBy(tally).toFixed(3),
-        window: WINDOW,
-        rate: tally.rate ? +tally.rate.toFixed(2) : null,
-        claimed: tally.fps
-    };
 
     tally.previous = step.reseed ? null : current;
 }
 
 // A timer, not timeupdate: the platform player does not always fire it while advancing.
 const watch = (video) => {
-    const tally = tallyFor(video);
-    if (tally.watching) return;
+    if (tallyFor(video).watching) return;
 
-    tally.watching = true;
+    tallyFor(video).watching = true;
 
     const stop = () => {
+        const tally = tallyFor(video);
         clearInterval(tally.timer);
         tally.timer = null;
-        tally.previous = null;
+        forget();
     };
 
     const start = () => {
-        if (tally.timer) return;
+        const tally = tallyFor(video);
+        if (tally.timer || !configRead('reportPlaybackStats')) return;
         tally.timer = setInterval(() => sample(video), TICK);
     };
 
     const restart = () => {
         stop();
-        Object.assign(tally, blank(), { watching: true });
-        dropLabel(tally);
+        dropLabel(tallyFor(video));
+        tallies.set(video, { ...blank(), watching: true });
     };
 
-    const forget = () => { tally.previous = null; };
+    const forget = () => {
+        const tally = tallyFor(video);
+        tally.previous = null;
+        tally.rateFrames = 0;
+        tally.rateAt = 0;
+    };
 
     video.addEventListener('playing', start);
     video.addEventListener('pause', stop);
@@ -271,4 +227,4 @@ export function install() {
 
 export { WINDOW };
 
-if (typeof window !== 'undefined' && configRead('reportPlaybackStats')) install();
+if (typeof window !== 'undefined') install();

--- a/mods/features/playbackStats.js
+++ b/mods/features/playbackStats.js
@@ -1,0 +1,274 @@
+import { configRead } from '../config.js';
+
+// The platform player reports zero frames, so this measures lost time instead.
+
+const TICK = 250;
+const WINDOW = 30;
+
+// A longer gap is a suspended app, not playback, so it is charged to nobody.
+const MAX_GAP = 2;
+const MOST_RECENT = (WINDOW * 1000) / TICK;
+
+const DEFAULT_FPS = 60;
+const MAX_PLAUSIBLE_FPS = 200;
+const EMA = 0.3;
+
+// Looking for the panel costs a walk of the document, and a closed panel never opens by itself —
+// so a fruitless search backs off instead of repeating every two seconds for the whole video.
+const FIND_EVERY = 2000;
+const FIND_AT_MOST_EVERY = 30000;
+
+const PLAYER = '#movie_player, .html5-video-player';
+const MARK = 'data-tube-lost';
+
+// Both sides, not their difference: shortfalls only add, so jitter would read as lost time.
+export function account(previous, current) {
+    const none = { played: 0, expected: 0, advanced: 0, reseed: false };
+    const drop = { played: 0, expected: 0, advanced: 0, reseed: true };
+
+    if (!current || current.paused || current.seeking) return drop;
+    if (!previous) return none;
+
+    const wall = (current.wall - previous.wall) / 1000;
+    if (wall <= 0 || wall > MAX_GAP) return drop;
+
+    const advanced = current.media - previous.media;
+    const expected = wall * (previous.rate || 1);
+
+    if (advanced < 0 || advanced > expected * 4) return drop;
+
+    return { played: Math.min(advanced, expected), expected, advanced, reseed: false };
+}
+
+export function lostBy(tally) {
+    if (!tally.recent || !tally.recent.length) {
+        return Math.max(0, (tally.expected || 0) - (tally.advanced || 0));
+    }
+
+    const summed = tally.recent.reduce(
+        (total, step) => ({ expected: total.expected + step.expected, advanced: total.advanced + step.advanced }),
+        { expected: 0, advanced: 0 }
+    );
+
+    return Math.max(0, summed.expected - summed.advanced);
+}
+
+const tallies = new WeakMap();
+
+const blank = () => ({
+    expected: 0,
+    advanced: 0,
+    recent: [],
+    fps: DEFAULT_FPS,
+    width: -1,
+    height: -1,
+    previous: null,
+    watching: false,
+    timer: null,
+    rate: 0,
+    rateFrames: 0,
+    rateAt: 0,
+    node: null,
+    label: null,
+    lookedAt: 0,
+    lookGap: FIND_EVERY
+});
+
+const tallyFor = (video) => {
+    const held = tallies.get(video);
+    if (held) return held;
+
+    const made = blank();
+    tallies.set(video, made);
+    return made;
+};
+
+const latest = { reading: null };
+
+export const measured = () => latest.reading;
+
+// -- what the renderer says ----------------------------------------------------------------------
+
+const playerElement = () => document.querySelector(PLAYER);
+
+const measureRate = (video, tally, wall) => {
+    // The prototype's own, so a patched getVideoPlaybackQuality is not averaged into itself.
+    const proto = window.HTMLVideoElement && window.HTMLVideoElement.prototype;
+    const real = proto && proto.getVideoPlaybackQuality;
+    const quality = real ? real.call(video) : null;
+
+    if (!quality || !quality.totalVideoFrames) return;
+
+    const frames = quality.totalVideoFrames;
+    const elapsed = wall - tally.rateAt;
+
+    if (tally.rateAt && elapsed > 0) {
+        const perSecond = ((frames - tally.rateFrames) * 1000) / elapsed;
+
+        if (perSecond >= 0 && perSecond < MAX_PLAUSIBLE_FPS) {
+            tally.rate = tally.rate ? tally.rate * (1 - EMA) + perSecond * EMA : perSecond;
+        }
+    }
+
+    tally.rateFrames = frames;
+    tally.rateAt = wall;
+};
+
+const frameRate = (video, tally) => {
+    if (video.videoWidth === tally.width && video.videoHeight === tally.height) return;
+
+    tally.width = video.videoWidth;
+    tally.height = video.videoHeight;
+
+    try {
+        const found = /@(\d+(?:\.\d+)?)/.exec(playerElement().getStatsForNerds().resolution || '');
+        if (found) tally.fps = parseFloat(found[1]) || tally.fps;
+    } catch (e) { /* no panel, or a build that does not answer */ }
+};
+
+// -- the label on the stats panel ------------------------------------------------------------------
+
+// find.call over the NodeList rather than Array.from(...).find: it short-circuits and copies
+// nothing, and this walks every div, span and pre on the page.
+const framesNode = () => {
+    const isTheFramesLine = (node) => !node.children.length
+        && node.textContent.indexOf('dropped of') !== -1;
+
+    return Array.prototype.find.call(document.querySelectorAll('div, span, pre'), isTheFramesLine) || null;
+};
+
+const said = (tally) => {
+    const lost = lostBy(tally);
+    const time = lost >= 0.05 ? `~${lost.toFixed(1)}s lost` : '~no time lost';
+
+    return tally.rate ? `@ ${tally.rate.toFixed(2)} fps · ${time}` : time;
+};
+
+// The panel is re-rendered under us, so the label is found by its mark rather than remembered, and
+// any duplicate a re-render left behind is removed.
+const showRate = (tally, wall) => {
+    if (!tally.node || !tally.node.isConnected) {
+        if (wall - tally.lookedAt < tally.lookGap) return;
+
+        tally.lookedAt = wall;
+        tally.node = framesNode();
+
+        if (!tally.node) {
+            tally.lookGap = Math.min(tally.lookGap * 2, FIND_AT_MOST_EVERY);
+            return;
+        }
+
+        tally.lookGap = FIND_EVERY;
+    }
+
+    const row = tally.node.parentNode;
+    const already = row.querySelectorAll(`[${MARK}]`);
+
+    Array.from(already).slice(1).forEach((duplicate) => duplicate.remove());
+
+    tally.label = already[0] || null;
+
+    if (!tally.label) {
+        tally.label = document.createElement('span');
+        tally.label.setAttribute(MARK, '');
+        tally.label.style.cssText = 'display:inline;white-space:pre';
+        row.insertBefore(tally.label, tally.node.nextSibling);
+    }
+
+    tally.label.textContent = `  ${said(tally)}`;
+};
+
+const dropLabel = (tally) => {
+    if (tally.label && tally.label.parentNode) tally.label.parentNode.removeChild(tally.label);
+    tally.label = null;
+    tally.node = null;
+};
+
+// -- sampling ---------------------------------------------------------------------------------------
+
+export function sample(video) {
+    const tally = tallyFor(video);
+
+    // The player swaps elements without ending playback; a timer on a detached one keeps it alive.
+    if (video.isConnected === false) {
+        clearInterval(tally.timer);
+        tally.timer = null;
+        return;
+    }
+
+    const current = {
+        wall: Date.now(),
+        media: video.currentTime,
+        rate: video.playbackRate,
+        paused: video.paused,
+        seeking: video.seeking,
+        readyState: video.readyState
+    };
+
+    const step = account(tally.previous, current);
+
+    tally.expected += step.expected;
+    tally.advanced += step.advanced;
+    tally.recent.push({ expected: step.expected, advanced: step.advanced });
+    tally.recent.splice(0, Math.max(0, tally.recent.length - MOST_RECENT));
+
+    frameRate(video, tally);
+    measureRate(video, tally, current.wall);
+    showRate(tally, current.wall);
+
+    latest.reading = {
+        lost: +lostBy(tally).toFixed(3),
+        window: WINDOW,
+        rate: tally.rate ? +tally.rate.toFixed(2) : null,
+        claimed: tally.fps
+    };
+
+    tally.previous = step.reseed ? null : current;
+}
+
+// A timer, not timeupdate: the platform player does not always fire it while advancing.
+const watch = (video) => {
+    const tally = tallyFor(video);
+    if (tally.watching) return;
+
+    tally.watching = true;
+
+    const stop = () => {
+        clearInterval(tally.timer);
+        tally.timer = null;
+        tally.previous = null;
+    };
+
+    const start = () => {
+        if (tally.timer) return;
+        tally.timer = setInterval(() => sample(video), TICK);
+    };
+
+    const restart = () => {
+        stop();
+        Object.assign(tally, blank(), { watching: true });
+        dropLabel(tally);
+    };
+
+    const forget = () => { tally.previous = null; };
+
+    video.addEventListener('playing', start);
+    video.addEventListener('pause', stop);
+    video.addEventListener('ended', stop);
+    video.addEventListener('loadstart', restart);
+    video.addEventListener('emptied', restart);
+    video.addEventListener('seeking', forget);
+    video.addEventListener('ratechange', forget);
+
+    if (!video.paused) start();
+};
+
+export function install() {
+    document.addEventListener('play', (event) => {
+        if (event.target instanceof window.HTMLVideoElement) watch(event.target);
+    }, true);
+}
+
+export { WINDOW };
+
+if (typeof window !== 'undefined' && configRead('reportPlaybackStats')) install();

--- a/mods/features/preferredVideoQuality.js
+++ b/mods/features/preferredVideoQuality.js
@@ -102,7 +102,7 @@ function watchPreferredQuality() {
             player.addEventListener('onStateChange', tick);
             tick();
         },
-        { every: ATTACH_EVERY }
+        { everyMs: ATTACH_EVERY }
     );
 
     function tick() {

--- a/mods/features/preferredVideoQuality.js
+++ b/mods/features/preferredVideoQuality.js
@@ -14,8 +14,6 @@ const LIMITS = { maxAttempts: 3, retryDelay: 5000 };
 const RESTART_JUMP = 2;
 
 function watchPreferredQuality() {
-    // Everything that changes, in one place: which player we are attached to, which rung we last
-    // asked for, and whether the choice has settled.
     const held = {
         player: null,
         lastVideoId: null,
@@ -37,7 +35,7 @@ function watchPreferredQuality() {
     const startedOver = (player) => {
         const id = player.getVideoData?.()?.video_id;
         const time = player.getCurrentTime?.() ?? 0;
-        const looped = time + RESTART_JUMP < held.lastTime;
+        const looped = time < RESTART_JUMP && time + RESTART_JUMP < held.lastTime;
 
         held.lastTime = time;
 
@@ -56,20 +54,20 @@ function watchPreferredQuality() {
     };
 
     const askFor = (player, chosen, current) => {
-        const again = chosen.quality === held.target;
+        const again = chosen === held.target;
 
         const state = {
             current,
-            wanted: chosen.quality,
-            target: held.target,
+            wanted: chosen,
+            again,
             attempts: held.attempts,
             askedAt: held.askedAt
         };
 
         if (!shouldAsk(state, Date.now(), LIMITS)) return;
 
-        player.setPlaybackQualityRange(chosen.quality, chosen.quality);
-        held.target = chosen.quality;
+        player.setPlaybackQualityRange(chosen, chosen);
+        held.target = chosen;
         held.attempts = again ? held.attempts + 1 : 1;
         held.askedAt = Date.now();
     };
@@ -88,7 +86,7 @@ function watchPreferredQuality() {
 
         const current = player.getPlaybackQuality();
 
-        if (current === chosen.quality) {
+        if (current === chosen) {
             held.attempts = 0;
             held.settled = true;
             return;
@@ -137,9 +135,7 @@ function watchPreferredQuality() {
     attachToPlayer();
 }
 
-// Not inside Cobalt's container. Asking restarts the stream, and the container's player does not
-// report the rung back under the name we asked for, so the retry never settles — three asks, five
-// seconds apart, and the third wedges playback for good about fifteen seconds in.
+// Cobalt reports the rung under a different name, so asking never settles and wedges playback.
 const inCobalt = typeof navigator !== 'undefined' && /Cobalt/i.test(navigator.userAgent || '');
 
 if (typeof window !== 'undefined' && !inCobalt) watchPreferredQuality();

--- a/mods/features/preferredVideoQuality.js
+++ b/mods/features/preferredVideoQuality.js
@@ -1,113 +1,145 @@
-import { configRead, configChangeEmitter } from "../config.js";
+import { configRead, configChangeEmitter } from '../config.js';
+import { waitFor } from '../utils/waitFor.js';
+import { chooseQuality, shouldAsk } from './quality.js';
 
-const SELECTORS = {
-    PLAYER: '.html5-video-player',
-};
+const PLAYER = '.html5-video-player';
+const QUALITY = 'preferredVideoQuality';
 
-const EVENTS = {
-    YT_STATE_CHANGE: 'onStateChange',
-    CONFIG_CHANGE: 'configChange',
-};
+const CHECK_INTERVAL = 3000;
+const ATTACH_EVERY = 250;
 
-const CONFIG_KEYS = {
-    QUALITY: 'preferredVideoQuality',
-};
+// Asking restarts the stream, so a rung the player will not take is dropped after a few tries.
+const LIMITS = { maxAttempts: 3, retryDelay: 5000 };
 
-class PreferredQualityHandler {
-    #player = null;
-    #attachTimeout = null;
-    #lastVideoId = null;
-    #hasAppliedQuality = false;
+const RESTART_JUMP = 2;
 
-    constructor() {
-        this.init();
-    }
+function watchPreferredQuality() {
+    // Everything that changes, in one place: which player we are attached to, which rung we last
+    // asked for, and whether the choice has settled.
+    const held = {
+        player: null,
+        lastVideoId: null,
+        lastTime: 0,
+        target: null,
+        attempts: 0,
+        askedAt: 0,
+        // Without this, a quality chosen from the player's own menu is overridden on the next tick.
+        settled: false
+    };
 
-    init() {
-        this.#pollForPlayer();
-        this.#setupConfigListener();
-    }
+    const forget = () => {
+        held.target = null;
+        held.attempts = 0;
+        held.askedAt = 0;
+        held.settled = false;
+    };
 
-    #pollForPlayer() {
-        clearTimeout(this.#attachTimeout);
+    const startedOver = (player) => {
+        const id = player.getVideoData?.()?.video_id;
+        const time = player.getCurrentTime?.() ?? 0;
+        const looped = time + RESTART_JUMP < held.lastTime;
 
-        const playerElement = document.querySelector(SELECTORS.PLAYER);
+        held.lastTime = time;
 
-        if (!playerElement) {
-            this.#attachTimeout = setTimeout(() => this.#pollForPlayer(), 100);
-            return;
-        }
+        if (id === held.lastVideoId && !looped) return false;
 
-        this.#player = playerElement;
+        held.lastVideoId = id;
+        return true;
+    };
 
-        this.#player.addEventListener(EVENTS.YT_STATE_CHANGE, this.#handleStateChange);
-
-        this.#handleStateChange();
-    }
-
-    #setupConfigListener() {
-        configChangeEmitter.addEventListener(EVENTS.CONFIG_CHANGE, (ev) => {
-            if (ev.detail?.key === CONFIG_KEYS.QUALITY) {
-                this.#applyQuality();
-            }
-        });
-    }
-
-    #handleStateChange = () => {
-        const state = this.#player?.getPlayerStateObject?.();
-        const videoData = this.#player?.getVideoData?.();
-        const videoId = videoData?.video_id;
-
-        if (videoId !== this.#lastVideoId) {
-            this.#lastVideoId = videoId;
-            this.#hasAppliedQuality = false;
-        }
-
-        const isShorts = Object.values(this.#player.getVideoStats()).find(a => a && a === 'shortspage');
-        if (state?.isPlaying && !this.#hasAppliedQuality && !isShorts) {
-            this.#applyQuality();
-            this.#hasAppliedQuality = true;
+    const isShorts = (player) => {
+        try {
+            return Object.values(player.getVideoStats()).some((value) => value === 'shortspage');
+        } catch (e) {
+            return false;
         }
     };
 
-    #applyQuality() {
-        const preferredQuality = configRead(CONFIG_KEYS.QUALITY);
-        if (!preferredQuality || preferredQuality === 'auto' || !this.#player) return;
+    const askFor = (player, chosen, current) => {
+        const again = chosen.quality === held.target;
+
+        const state = {
+            current,
+            wanted: chosen.quality,
+            target: held.target,
+            attempts: held.attempts,
+            askedAt: held.askedAt
+        };
+
+        if (!shouldAsk(state, Date.now(), LIMITS)) return;
+
+        player.setPlaybackQualityRange(chosen.quality, chosen.quality);
+        held.target = chosen.quality;
+        held.attempts = again ? held.attempts + 1 : 1;
+        held.askedAt = Date.now();
+    };
+
+    const applyPreference = (player) => {
+        if (startedOver(player)) forget();
+        if (held.settled) return;
+
+        const preference = configRead(QUALITY);
+        if (!preference || preference === 'auto') return;
+        if (!player.getPlayerStateObject?.()?.isPlaying) return;
+        if (isShorts(player)) return;
+
+        const chosen = chooseQuality(preference, player.getAvailableQualityData());
+        if (!chosen) return;
+
+        const current = player.getPlaybackQuality();
+
+        if (current === chosen.quality) {
+            held.attempts = 0;
+            held.settled = true;
+            return;
+        }
+
+        askFor(player, chosen, current);
+    };
+
+    const attachToPlayer = () => waitFor(
+        () => document.querySelector(PLAYER),
+        (player) => {
+            held.player = player;
+            player.addEventListener('onStateChange', tick);
+            tick();
+        },
+        { every: ATTACH_EVERY }
+    );
+
+    function tick() {
+        if (!held.player) return;
+
+        // The player element is replaced on some navigations, which leaves the listener on a node
+        // nothing plays through any more.
+        if (held.player.isConnected === false) {
+            held.player = null;
+            forget();
+            attachToPlayer();
+            return;
+        }
 
         try {
-            const quality = this.#determineQuality(preferredQuality);
-
-            if (quality) {
-              this.#player.setPlaybackQualityRange(quality, quality)
-            }
+            applyPreference(held.player);
         } catch (e) {
-            console.warn('[PreferredQuality] Failed to apply quality:', e);
+            console.warn('[tube] could not apply the preferred quality:', e);
         }
     }
 
-    #determineQuality(preference) {
-        const available = (this.#player.getAvailableQualityData() || [])
-            .filter((entry) => entry && entry.isPlayable !== false);
+    configChangeEmitter.addEventListener('configChange', (event) => {
+        if (event.detail?.key !== QUALITY) return;
 
-        if (!available.length) return null;
+        forget();
+        tick();
+    });
 
-        const pixels = (entry) => parseInt(entry.qualityLabel, 10) || 0;
-
-        if (preference === 'highest') {
-            return available.reduce((best, entry) => (pixels(entry) > pixels(best) ? entry : best)).quality;
-        }
-
-        const target = parseInt(preference, 10) || 0;
-        const match = available.find((entry) => pixels(entry) === target);
-
-        if (match) return match.quality;
-
-        const below = available
-            .filter((entry) => pixels(entry) <= target)
-            .reduce((best, entry) => (!best || pixels(entry) > pixels(best) ? entry : best), null);
-
-        return below ? below.quality : null;
-    }
+    setInterval(tick, CHECK_INTERVAL);
+    attachToPlayer();
 }
 
-window.preferredVideoQualityHandler = new PreferredQualityHandler();
+// Not inside Cobalt's container. Asking restarts the stream, and the container's player does not
+// report the rung back under the name we asked for, so the retry never settles — three asks, five
+// seconds apart, and the third wedges playback for good about fifteen seconds in.
+const inCobalt = typeof navigator !== 'undefined' && /Cobalt/i.test(navigator.userAgent || '');
+
+if (typeof window !== 'undefined' && !inCobalt) watchPreferredQuality();

--- a/mods/features/quality.js
+++ b/mods/features/quality.js
@@ -1,0 +1,32 @@
+export function chooseQuality(preference, offered) {
+    const available = (offered || []).filter((entry) => entry && entry.isPlayable !== false);
+    if (!available.length) return null;
+
+    const pixels = (entry) => parseInt(entry.qualityLabel, 10) || 0;
+
+    if (preference === 'highest') {
+        const best = available.reduce((top, entry) => (pixels(entry) > pixels(top) ? entry : top));
+        return { quality: best.quality, pixels: pixels(best) };
+    }
+
+    const target = parseInt(preference, 10) || 0;
+    const match = available.find((entry) => pixels(entry) === target);
+
+    if (match) return { quality: match.quality, pixels: pixels(match) };
+
+    const below = available
+        .filter((entry) => pixels(entry) <= target)
+        .reduce((best, entry) => (!best || pixels(entry) > pixels(best) ? entry : best), null);
+
+    return below ? { quality: below.quality, pixels: pixels(below) } : null;
+}
+
+export function shouldAsk({ current, wanted, target, attempts, askedAt }, now, limits) {
+    if (!wanted || current === wanted) return false;
+
+    const again = wanted === target;
+    if (again && attempts >= limits.maxAttempts) return false;
+    if (again && now - askedAt < limits.retryDelay) return false;
+
+    return true;
+}

--- a/mods/features/quality.js
+++ b/mods/features/quality.js
@@ -6,25 +6,24 @@ export function chooseQuality(preference, offered) {
 
     if (preference === 'highest') {
         const best = available.reduce((top, entry) => (pixels(entry) > pixels(top) ? entry : top));
-        return { quality: best.quality, pixels: pixels(best) };
+        return best.quality;
     }
 
     const target = parseInt(preference, 10) || 0;
     const match = available.find((entry) => pixels(entry) === target);
 
-    if (match) return { quality: match.quality, pixels: pixels(match) };
+    if (match) return match.quality;
 
     const below = available
         .filter((entry) => pixels(entry) <= target)
         .reduce((best, entry) => (!best || pixels(entry) > pixels(best) ? entry : best), null);
 
-    return below ? { quality: below.quality, pixels: pixels(below) } : null;
+    return below ? below.quality : null;
 }
 
-export function shouldAsk({ current, wanted, target, attempts, askedAt }, now, limits) {
+export function shouldAsk({ current, wanted, again, attempts, askedAt }, now, limits) {
     if (!wanted || current === wanted) return false;
 
-    const again = wanted === target;
     if (again && attempts >= limits.maxAttempts) return false;
     if (again && now - askedAt < limits.retryDelay) return false;
 

--- a/mods/package.json
+++ b/mods/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "rollup -c rollup.config.js && node ../tools/check-output.js ../dist/userScript.js cobalt3",
-    "test": "node test/wait-for.js"
+    "test": "node test/playback-stats.js && node test/quality.js && node test/wait-for.js"
   },
   "keywords": [],
   "author": "tube contributors, derived from TizenTube and youtube-webos (GPL-3.0)",

--- a/mods/test/playback-stats.js
+++ b/mods/test/playback-stats.js
@@ -1,9 +1,8 @@
-import * as stats from '../features/playbackStats.js';
-import { account, lostBy, install } from '../features/playbackStats.js';
+import { account, lostBy, WINDOW } from '../features/playbackStats.js';
 
 const SLIGHT_LAG = 0.01;
 
-const shortfall = (step) => lostBy({ expected: step.expected, advanced: step.advanced });
+const shortfall = (step) => lostBy({ recent: [step] });
 
 const results = [];
 function check(name, ok, detail) {
@@ -12,14 +11,14 @@ function check(name, ok, detail) {
 }
 
 const at = (wall, media, over) => Object.assign(
-    { wall, media, rate: 1, paused: false, seeking: false, readyState: 4 }, over || {}
+    { wall, media, speed: 1, paused: false, seeking: false }, over || {}
 );
 
 {
     const step = account(at(0, 10), at(1000, 11));
     check('smooth playback loses nothing', shortfall(step) === 0, JSON.stringify(step));
     check('smooth playback counts a second played',
-        Math.abs(step.played - 1) < 1e-9, JSON.stringify(step));
+        Math.abs(step.advanced - 1) < 1e-9, JSON.stringify(step));
 }
 
 {
@@ -27,12 +26,12 @@ const at = (wall, media, over) => Object.assign(
     check('a hitch is charged as lost time',
         Math.abs(shortfall(step) - 0.5) < 1e-9, JSON.stringify(step));
     check('a hitch still counts what did play',
-        Math.abs(step.played - 0.5) < 1e-9, JSON.stringify(step));
+        Math.abs(step.advanced - 0.5) < 1e-9, JSON.stringify(step));
 }
 
 {
-    const step = account(at(0, 10, { readyState: 4 }), at(1000, 10, { readyState: 1 }));
-    check('a rebuffer is charged as lost time',
+    const step = account(at(0, 10), at(1000, 10));
+    check('a clock that stands still is charged as lost time',
         Math.abs(shortfall(step) - 1) < 1e-9, JSON.stringify(step));
 }
 
@@ -43,7 +42,7 @@ const at = (wall, media, over) => Object.assign(
 
 {
     const paused = account(at(0, 10), at(1000, 10, { paused: true }));
-    check('a pause costs nothing', shortfall(paused) === 0 && paused.played === 0, JSON.stringify(paused));
+    check('a pause costs nothing', shortfall(paused) === 0 && paused.advanced === 0, JSON.stringify(paused));
     check('a pause drops the baseline', paused.reseed === true, JSON.stringify(paused));
 }
 
@@ -53,7 +52,7 @@ const at = (wall, media, over) => Object.assign(
 
     const jump = account(at(0, 10), at(1000, 90));
     check('a forward jump is not counted as playback',
-        jump.played === 0 && shortfall(jump) === 0, JSON.stringify(jump));
+        jump.advanced === 0 && shortfall(jump) === 0, JSON.stringify(jump));
     check('a forward jump drops the baseline', jump.reseed === true, JSON.stringify(jump));
 }
 
@@ -64,10 +63,10 @@ const at = (wall, media, over) => Object.assign(
 }
 
 {
-    const step = account(at(0, 10, { rate: 2 }), at(1000, 12, { rate: 2 }));
+    const step = account(at(0, 10, { speed: 2 }), at(1000, 12, { speed: 2 }));
     check('double speed keeping up loses nothing', shortfall(step) === 0, JSON.stringify(step));
 
-    const behind = account(at(0, 10, { rate: 2 }), at(1000, 11, { rate: 2 }));
+    const behind = account(at(0, 10, { speed: 2 }), at(1000, 11, { speed: 2 }));
     check('double speed falling behind is charged',
         Math.abs(shortfall(behind) - 1) < 1e-9, JSON.stringify(behind));
 }
@@ -80,57 +79,28 @@ const at = (wall, media, over) => Object.assign(
 
 {
     const step = account(null, at(0, 10));
-    check('the first sample counts nothing', step.played === 0 && shortfall(step) === 0, JSON.stringify(step));
+    check('the first sample counts nothing', step.advanced === 0 && shortfall(step) === 0, JSON.stringify(step));
 }
 
-{
-    const video = {
-        currentTime: 0, playbackRate: 1, paused: false, seeking: false, readyState: 4,
-        videoWidth: 3840, videoHeight: 2160,
-        addEventListener() {}
-    };
-
-    const native = { totalVideoFrames: 0, droppedVideoFrames: 0, creationTime: 0 };
-
-    global.window = { HTMLVideoElement: function () {} };
-    global.window.HTMLVideoElement.prototype.getVideoPlaybackQuality = function () { return native; };
-    global.document = { addEventListener() {}, querySelector() { return null; } };
-
-    const before = global.window.HTMLVideoElement.prototype.getVideoPlaybackQuality;
-    install();
-    const after = global.window.HTMLVideoElement.prototype.getVideoPlaybackQuality;
-
-    check('the renderer is left to answer for itself', after === before,
-        'getVideoPlaybackQuality was replaced');
-    check('and what it says is passed through unchanged',
-        after.call(video).droppedVideoFrames === 0, 'a count was invented');
-}
-
-// Sampling jitter is zero-mean, and charging each sample's shortfall as it happens turns
-// it into a large positive total. Measured against thirty seconds of the television's own
-// playback: the media clock kept up exactly, and the old accounting still reported
-// forty-one dropped frames.
 const runFor = (fps, wobbleMs, ticks) => {
     const frame = 1 / fps;
     let wall = 0;
     let previous = null;
-    const tally = { played: 0, expected: 0, advanced: 0 };
+    const recent = [];
 
     for (let tick = 0; tick < ticks; tick++) {
         wall += 0.25 + (((tick % 2) ? wobbleMs : -wobbleMs) / 1000);
 
-        // The media clock reports whole frames, as it does when it carries the presented frame's
-        // timestamp, which is where the per-sample lag came from.
+        // The media clock reports whole frames.
         const media = Math.floor((wall / frame) + 1e-9) * frame;
-        const current = { wall: wall * 1000, media, rate: 1, paused: false, seeking: false };
+        const current = { wall: wall * 1000, media, speed: 1, paused: false, seeking: false };
         const step = account(previous, current);
 
-        tally.expected += step.expected;
-        tally.advanced += step.advanced;
+        recent.push(step);
         previous = step.reseed ? null : current;
     }
 
-    return lostBy(tally) * fps;
+    return lostBy({ recent }) * fps;
 };
 
 check('jitter at twenty-four frames a second is not charged as loss',
@@ -139,29 +109,25 @@ check('nor at thirty', runFor(30, 20, 240) < 1, `${runFor(30, 20, 240).toFixed(1
 check('nor at sixty', runFor(60, 10, 240) < 1, `${runFor(60, 10, 240).toFixed(1)} frames`);
 
 const stall = (() => {
-    const tally = { played: 0, expected: 0, advanced: 0 };
-    let previous = { wall: 0, media: 10, rate: 1, paused: false, seeking: false };
+    const recent = [];
+    let previous = { wall: 0, media: 10, speed: 1, paused: false, seeking: false };
 
     for (let at = 1; at <= 8; at++) {
         const stopped = at <= 4;
         const current = { wall: at * 250, media: stopped ? 10 : 10 + ((at - 4) * 0.25),
-            rate: 1, paused: false, seeking: false };
+            speed: 1, paused: false, seeking: false };
         const step = account(previous, current);
-        tally.expected += step.expected;
-        tally.advanced += step.advanced;
+        recent.push(step);
         previous = step.reseed ? null : current;
     }
 
-    return lostBy(tally);
+    return lostBy({ recent });
 })();
 
 check('a stall is still counted in full', Math.abs(stall - 1) < 0.01, `${stall.toFixed(3)}s`);
 
-// A cumulative figure is dominated for ever by whatever happened at startup: measured on
-// the set, a video reported six hundred dropped frames for four minutes while losing
-// nothing after the first few seconds.
 const overTime = (stallSeconds, thenSmoothSeconds) => {
-    const tally = { played: 0, expected: 0, advanced: 0, recent: [] };
+    const tally = { recent: [] };
     let wall = 0;
     let media = 0;
     let previous = null;
@@ -170,13 +136,11 @@ const overTime = (stallSeconds, thenSmoothSeconds) => {
         wall += 0.25;
         if (advancing) media += 0.25;
 
-        const current = { wall: wall * 1000, media, rate: 1, paused: false, seeking: false };
+        const current = { wall: wall * 1000, media, speed: 1, paused: false, seeking: false };
         const step = account(previous, current);
 
-        tally.expected += step.expected;
-        tally.advanced += step.advanced;
         tally.recent.push({ expected: step.expected, advanced: step.advanced });
-        while (tally.recent.length > (stats.WINDOW * 1000) / 250) tally.recent.shift();
+        while (tally.recent.length > (WINDOW * 1000) / 250) tally.recent.shift();
 
         previous = step.reseed ? null : current;
     };
@@ -190,7 +154,7 @@ const overTime = (stallSeconds, thenSmoothSeconds) => {
 check('a stall is reported while it is recent',
     Math.abs(overTime(5, 2) - 5) < 0.3, `${overTime(5, 2).toFixed(2)}s`);
 check('and ages out once playback has been fine for the window',
-    overTime(5, stats.WINDOW + 5) < 0.3, `${overTime(5, stats.WINDOW + 5).toFixed(2)}s`);
+    overTime(5, WINDOW + 5) < 0.3, `${overTime(5, WINDOW + 5).toFixed(2)}s`);
 
 const failed = results.filter((ok) => !ok).length;
 console.log(`\n${results.length - failed}/${results.length} checks passed.`);

--- a/mods/test/playback-stats.js
+++ b/mods/test/playback-stats.js
@@ -1,0 +1,197 @@
+import * as stats from '../features/playbackStats.js';
+import { account, lostBy, install } from '../features/playbackStats.js';
+
+const SLIGHT_LAG = 0.01;
+
+const shortfall = (step) => lostBy({ expected: step.expected, advanced: step.advanced });
+
+const results = [];
+function check(name, ok, detail) {
+    results.push(ok);
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : `  <- ${detail}`}`);
+}
+
+const at = (wall, media, over) => Object.assign(
+    { wall, media, rate: 1, paused: false, seeking: false, readyState: 4 }, over || {}
+);
+
+{
+    const step = account(at(0, 10), at(1000, 11));
+    check('smooth playback loses nothing', shortfall(step) === 0, JSON.stringify(step));
+    check('smooth playback counts a second played',
+        Math.abs(step.played - 1) < 1e-9, JSON.stringify(step));
+}
+
+{
+    const step = account(at(0, 10), at(1000, 10.5));
+    check('a hitch is charged as lost time',
+        Math.abs(shortfall(step) - 0.5) < 1e-9, JSON.stringify(step));
+    check('a hitch still counts what did play',
+        Math.abs(step.played - 0.5) < 1e-9, JSON.stringify(step));
+}
+
+{
+    const step = account(at(0, 10, { readyState: 4 }), at(1000, 10, { readyState: 1 }));
+    check('a rebuffer is charged as lost time',
+        Math.abs(shortfall(step) - 1) < 1e-9, JSON.stringify(step));
+}
+
+{
+    const step = account(at(0, 10), at(1000, 1 + 10 - SLIGHT_LAG));
+    check('a sample that lags slightly records it', shortfall(step) > 0, JSON.stringify(step));
+}
+
+{
+    const paused = account(at(0, 10), at(1000, 10, { paused: true }));
+    check('a pause costs nothing', shortfall(paused) === 0 && paused.played === 0, JSON.stringify(paused));
+    check('a pause drops the baseline', paused.reseed === true, JSON.stringify(paused));
+}
+
+{
+    const seeking = account(at(0, 10), at(1000, 90, { seeking: true }));
+    check('a seek costs nothing', shortfall(seeking) === 0, JSON.stringify(seeking));
+
+    const jump = account(at(0, 10), at(1000, 90));
+    check('a forward jump is not counted as playback',
+        jump.played === 0 && shortfall(jump) === 0, JSON.stringify(jump));
+    check('a forward jump drops the baseline', jump.reseed === true, JSON.stringify(jump));
+}
+
+{
+    const step = account(at(0, 313), at(1000, 0.5));
+    check('a loop is not charged as lost time', shortfall(step) === 0, JSON.stringify(step));
+    check('a loop drops the baseline', step.reseed === true, JSON.stringify(step));
+}
+
+{
+    const step = account(at(0, 10, { rate: 2 }), at(1000, 12, { rate: 2 }));
+    check('double speed keeping up loses nothing', shortfall(step) === 0, JSON.stringify(step));
+
+    const behind = account(at(0, 10, { rate: 2 }), at(1000, 11, { rate: 2 }));
+    check('double speed falling behind is charged',
+        Math.abs(shortfall(behind) - 1) < 1e-9, JSON.stringify(behind));
+}
+
+{
+    const step = account(at(0, 10), at(30000, 11));
+    check('a long gap is not charged to anyone', shortfall(step) === 0, JSON.stringify(step));
+    check('a long gap drops the baseline', step.reseed === true, JSON.stringify(step));
+}
+
+{
+    const step = account(null, at(0, 10));
+    check('the first sample counts nothing', step.played === 0 && shortfall(step) === 0, JSON.stringify(step));
+}
+
+{
+    const video = {
+        currentTime: 0, playbackRate: 1, paused: false, seeking: false, readyState: 4,
+        videoWidth: 3840, videoHeight: 2160,
+        addEventListener() {}
+    };
+
+    const native = { totalVideoFrames: 0, droppedVideoFrames: 0, creationTime: 0 };
+
+    global.window = { HTMLVideoElement: function () {} };
+    global.window.HTMLVideoElement.prototype.getVideoPlaybackQuality = function () { return native; };
+    global.document = { addEventListener() {}, querySelector() { return null; } };
+
+    const before = global.window.HTMLVideoElement.prototype.getVideoPlaybackQuality;
+    install();
+    const after = global.window.HTMLVideoElement.prototype.getVideoPlaybackQuality;
+
+    check('the renderer is left to answer for itself', after === before,
+        'getVideoPlaybackQuality was replaced');
+    check('and what it says is passed through unchanged',
+        after.call(video).droppedVideoFrames === 0, 'a count was invented');
+}
+
+// Sampling jitter is zero-mean, and charging each sample's shortfall as it happens turns
+// it into a large positive total. Measured against thirty seconds of the television's own
+// playback: the media clock kept up exactly, and the old accounting still reported
+// forty-one dropped frames.
+const runFor = (fps, wobbleMs, ticks) => {
+    const frame = 1 / fps;
+    let wall = 0;
+    let previous = null;
+    const tally = { played: 0, expected: 0, advanced: 0 };
+
+    for (let tick = 0; tick < ticks; tick++) {
+        wall += 0.25 + (((tick % 2) ? wobbleMs : -wobbleMs) / 1000);
+
+        // The media clock reports whole frames, as it does when it carries the presented frame's
+        // timestamp, which is where the per-sample lag came from.
+        const media = Math.floor((wall / frame) + 1e-9) * frame;
+        const current = { wall: wall * 1000, media, rate: 1, paused: false, seeking: false };
+        const step = account(previous, current);
+
+        tally.expected += step.expected;
+        tally.advanced += step.advanced;
+        previous = step.reseed ? null : current;
+    }
+
+    return lostBy(tally) * fps;
+};
+
+check('jitter at twenty-four frames a second is not charged as loss',
+    runFor(24, 25, 240) < 1, `${runFor(24, 25, 240).toFixed(1)} frames`);
+check('nor at thirty', runFor(30, 20, 240) < 1, `${runFor(30, 20, 240).toFixed(1)} frames`);
+check('nor at sixty', runFor(60, 10, 240) < 1, `${runFor(60, 10, 240).toFixed(1)} frames`);
+
+const stall = (() => {
+    const tally = { played: 0, expected: 0, advanced: 0 };
+    let previous = { wall: 0, media: 10, rate: 1, paused: false, seeking: false };
+
+    for (let at = 1; at <= 8; at++) {
+        const stopped = at <= 4;
+        const current = { wall: at * 250, media: stopped ? 10 : 10 + ((at - 4) * 0.25),
+            rate: 1, paused: false, seeking: false };
+        const step = account(previous, current);
+        tally.expected += step.expected;
+        tally.advanced += step.advanced;
+        previous = step.reseed ? null : current;
+    }
+
+    return lostBy(tally);
+})();
+
+check('a stall is still counted in full', Math.abs(stall - 1) < 0.01, `${stall.toFixed(3)}s`);
+
+// A cumulative figure is dominated for ever by whatever happened at startup: measured on
+// the set, a video reported six hundred dropped frames for four minutes while losing
+// nothing after the first few seconds.
+const overTime = (stallSeconds, thenSmoothSeconds) => {
+    const tally = { played: 0, expected: 0, advanced: 0, recent: [] };
+    let wall = 0;
+    let media = 0;
+    let previous = null;
+
+    const tick = (advancing) => {
+        wall += 0.25;
+        if (advancing) media += 0.25;
+
+        const current = { wall: wall * 1000, media, rate: 1, paused: false, seeking: false };
+        const step = account(previous, current);
+
+        tally.expected += step.expected;
+        tally.advanced += step.advanced;
+        tally.recent.push({ expected: step.expected, advanced: step.advanced });
+        while (tally.recent.length > (stats.WINDOW * 1000) / 250) tally.recent.shift();
+
+        previous = step.reseed ? null : current;
+    };
+
+    for (let at = 0; at < stallSeconds * 4; at++) tick(false);
+    for (let at = 0; at < thenSmoothSeconds * 4; at++) tick(true);
+
+    return lostBy(tally);
+};
+
+check('a stall is reported while it is recent',
+    Math.abs(overTime(5, 2) - 5) < 0.3, `${overTime(5, 2).toFixed(2)}s`);
+check('and ages out once playback has been fine for the window',
+    overTime(5, stats.WINDOW + 5) < 0.3, `${overTime(5, stats.WINDOW + 5).toFixed(2)}s`);
+
+const failed = results.filter((ok) => !ok).length;
+console.log(`\n${results.length - failed}/${results.length} checks passed.`);
+process.exit(failed ? 1 : 0);

--- a/mods/test/quality.js
+++ b/mods/test/quality.js
@@ -1,0 +1,113 @@
+import { chooseQuality, shouldAsk } from '../features/quality.js';
+
+const results = [];
+function check(name, ok, detail) {
+    results.push(ok);
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : `  <- ${detail}`}`);
+}
+
+const rung = (label, quality, playable) => ({
+    qualityLabel: label, quality, isPlayable: playable !== false
+});
+
+const LADDER = [
+    rung('2160p', 'hd2160'), rung('1440p', 'hd1440'), rung('1080p', 'hd1080'),
+    rung('720p', 'hd720'), rung('480p', 'large'), rung('240p', 'small')
+];
+
+{
+    const top = chooseQuality('highest', LADDER);
+    check('highest takes the top rung', top.quality === 'hd2160', JSON.stringify(top));
+    check('highest reports the height it took', top.pixels === 2160, JSON.stringify(top));
+
+    const short = chooseQuality('highest', [rung('720p', 'hd720'), rung('480p', 'large')]);
+    check('highest on a short ladder takes its top', short.quality === 'hd720', JSON.stringify(short));
+}
+
+{
+    const exact = chooseQuality('1080p', LADDER);
+    check('a named rung is taken exactly', exact.quality === 'hd1080', JSON.stringify(exact));
+    check('a named rung reports its height', exact.pixels === 1080, JSON.stringify(exact));
+
+    const capped = chooseQuality('1080p', [rung('2160p', 'hd2160'), rung('1440p', 'hd1440')]);
+    check('a cap below everything offered does not reach up',
+        capped === null, JSON.stringify(capped));
+
+    const nearest = chooseQuality('1440p', [rung('2160p', 'hd2160'), rung('1080p', 'hd1080'), rung('720p', 'hd720')]);
+    check('a missing rung falls to the nearest below, not the maximum',
+        nearest.quality === 'hd1080', JSON.stringify(nearest));
+}
+
+{
+    const filtered = chooseQuality('highest', [
+        rung('2160p', 'hd2160', false),
+        rung('1080p', 'hd1080')
+    ]);
+    check('an unplayable rung is skipped even at the top',
+        filtered.quality === 'hd1080', JSON.stringify(filtered));
+
+    const allBad = chooseQuality('highest', [rung('2160p', 'hd2160', false)]);
+    check('a ladder of unplayable rungs answers nothing', allBad === null, JSON.stringify(allBad));
+}
+
+{
+    check('an empty ladder answers nothing', chooseQuality('highest', []) === null, 'expected null');
+    check('a missing ladder answers nothing', chooseQuality('highest', null) === null, 'expected null');
+    check('a missing ladder answers nothing for a named rung',
+        chooseQuality('1080p', undefined) === null, 'expected null');
+}
+
+{
+    const odd = chooseQuality('highest', [rung('auto', 'auto'), rung('1080p', 'hd1080')]);
+    check('a label with no number does not outrank a real rung',
+        odd.quality === 'hd1080', JSON.stringify(odd));
+}
+
+{
+    const early = chooseQuality('highest', [rung('720p', 'hd720')]);
+    const later = chooseQuality('highest', [rung('1080p', 'hd1080'), rung('720p', 'hd720')]);
+    const latest = chooseQuality('highest', LADDER);
+    check('a longer ladder answers higher than a shorter one',
+        early.pixels < later.pixels && later.pixels < latest.pixels,
+        `${early.pixels} ${later.pixels} ${latest.pixels}`);
+}
+
+{
+    const LIMITS = { maxAttempts: 3, retryDelay: 5000 };
+    const at = (over) => Object.assign(
+        { current: 'hd1080', wanted: 'hd2160', target: null, attempts: 0, askedAt: 0 }, over || {}
+    );
+
+    check('already on the wanted rung asks nothing',
+        shouldAsk(at({ current: 'hd2160' }), 10000, LIMITS) === false, 'expected false');
+
+    check('a rung we are not on is asked for',
+        shouldAsk(at(), 10000, LIMITS) === true, 'expected true');
+
+    check('nothing to want asks nothing',
+        shouldAsk(at({ wanted: null }), 10000, LIMITS) === false, 'expected false');
+
+    check('a video that looped back below its rung is asked again',
+        shouldAsk(at({ current: 'hd1440', target: 'hd2160', attempts: 1, askedAt: 0 }), 10000, LIMITS) === true,
+        'expected true');
+
+    check('the same rung is not asked for twice in a row too quickly',
+        shouldAsk(at({ target: 'hd2160', attempts: 1, askedAt: 9000 }), 10000, LIMITS) === false,
+        'expected false');
+
+    check('the same rung is asked again once the delay has passed',
+        shouldAsk(at({ target: 'hd2160', attempts: 1, askedAt: 1000 }), 10000, LIMITS) === true,
+        'expected true');
+
+    check('a rung the player will not take is given up on',
+        shouldAsk(at({ target: 'hd2160', attempts: 3, askedAt: 1000 }), 10000, LIMITS) === false,
+        'expected false');
+
+    check('a different rung is asked for even after giving up on the last',
+        shouldAsk(at({ wanted: 'hd1440', target: 'hd2160', attempts: 3, askedAt: 1000 }), 10000, LIMITS) === true,
+        'expected true');
+}
+
+const failed = results.filter((r) => !r).length;
+console.log(`\n${results.length - failed}/${results.length} checks passed.`);
+process.exit(failed ? 1 : 0);

--- a/mods/test/quality.js
+++ b/mods/test/quality.js
@@ -17,17 +17,15 @@ const LADDER = [
 
 {
     const top = chooseQuality('highest', LADDER);
-    check('highest takes the top rung', top.quality === 'hd2160', JSON.stringify(top));
-    check('highest reports the height it took', top.pixels === 2160, JSON.stringify(top));
+    check('highest takes the top rung', top === 'hd2160', JSON.stringify(top));
 
     const short = chooseQuality('highest', [rung('720p', 'hd720'), rung('480p', 'large')]);
-    check('highest on a short ladder takes its top', short.quality === 'hd720', JSON.stringify(short));
+    check('highest on a short ladder takes its top', short === 'hd720', JSON.stringify(short));
 }
 
 {
     const exact = chooseQuality('1080p', LADDER);
-    check('a named rung is taken exactly', exact.quality === 'hd1080', JSON.stringify(exact));
-    check('a named rung reports its height', exact.pixels === 1080, JSON.stringify(exact));
+    check('a named rung is taken exactly', exact === 'hd1080', JSON.stringify(exact));
 
     const capped = chooseQuality('1080p', [rung('2160p', 'hd2160'), rung('1440p', 'hd1440')]);
     check('a cap below everything offered does not reach up',
@@ -35,7 +33,7 @@ const LADDER = [
 
     const nearest = chooseQuality('1440p', [rung('2160p', 'hd2160'), rung('1080p', 'hd1080'), rung('720p', 'hd720')]);
     check('a missing rung falls to the nearest below, not the maximum',
-        nearest.quality === 'hd1080', JSON.stringify(nearest));
+        nearest === 'hd1080', JSON.stringify(nearest));
 }
 
 {
@@ -44,7 +42,7 @@ const LADDER = [
         rung('1080p', 'hd1080')
     ]);
     check('an unplayable rung is skipped even at the top',
-        filtered.quality === 'hd1080', JSON.stringify(filtered));
+        filtered === 'hd1080', JSON.stringify(filtered));
 
     const allBad = chooseQuality('highest', [rung('2160p', 'hd2160', false)]);
     check('a ladder of unplayable rungs answers nothing', allBad === null, JSON.stringify(allBad));
@@ -60,7 +58,7 @@ const LADDER = [
 {
     const odd = chooseQuality('highest', [rung('auto', 'auto'), rung('1080p', 'hd1080')]);
     check('a label with no number does not outrank a real rung',
-        odd.quality === 'hd1080', JSON.stringify(odd));
+        odd === 'hd1080', JSON.stringify(odd));
 }
 
 {
@@ -68,14 +66,14 @@ const LADDER = [
     const later = chooseQuality('highest', [rung('1080p', 'hd1080'), rung('720p', 'hd720')]);
     const latest = chooseQuality('highest', LADDER);
     check('a longer ladder answers higher than a shorter one',
-        early.pixels < later.pixels && later.pixels < latest.pixels,
-        `${early.pixels} ${later.pixels} ${latest.pixels}`);
+        early === 'hd720' && later === 'hd1080' && latest === 'hd2160',
+        `${early} ${later} ${latest}`);
 }
 
 {
     const LIMITS = { maxAttempts: 3, retryDelay: 5000 };
     const at = (over) => Object.assign(
-        { current: 'hd1080', wanted: 'hd2160', target: null, attempts: 0, askedAt: 0 }, over || {}
+        { current: 'hd1080', wanted: 'hd2160', again: false, attempts: 0, askedAt: 0 }, over || {}
     );
 
     check('already on the wanted rung asks nothing',
@@ -87,24 +85,20 @@ const LADDER = [
     check('nothing to want asks nothing',
         shouldAsk(at({ wanted: null }), 10000, LIMITS) === false, 'expected false');
 
-    check('a video that looped back below its rung is asked again',
-        shouldAsk(at({ current: 'hd1440', target: 'hd2160', attempts: 1, askedAt: 0 }), 10000, LIMITS) === true,
-        'expected true');
-
     check('the same rung is not asked for twice in a row too quickly',
-        shouldAsk(at({ target: 'hd2160', attempts: 1, askedAt: 9000 }), 10000, LIMITS) === false,
+        shouldAsk(at({ again: true, attempts: 1, askedAt: 9000 }), 10000, LIMITS) === false,
         'expected false');
 
     check('the same rung is asked again once the delay has passed',
-        shouldAsk(at({ target: 'hd2160', attempts: 1, askedAt: 1000 }), 10000, LIMITS) === true,
+        shouldAsk(at({ again: true, attempts: 1, askedAt: 1000 }), 10000, LIMITS) === true,
         'expected true');
 
     check('a rung the player will not take is given up on',
-        shouldAsk(at({ target: 'hd2160', attempts: 3, askedAt: 1000 }), 10000, LIMITS) === false,
+        shouldAsk(at({ again: true, attempts: 3, askedAt: 1000 }), 10000, LIMITS) === false,
         'expected false');
 
     check('a different rung is asked for even after giving up on the last',
-        shouldAsk(at({ wanted: 'hd1440', target: 'hd2160', attempts: 3, askedAt: 1000 }), 10000, LIMITS) === true,
+        shouldAsk(at({ wanted: 'hd1440', attempts: 3, askedAt: 1000 }), 10000, LIMITS) === true,
         'expected true');
 }
 

--- a/mods/ui/nativeSettings.js
+++ b/mods/ui/nativeSettings.js
@@ -1,7 +1,7 @@
 import { configRead, configChangeEmitter } from '../config.js';
 import { GROUPS, chosenLabel, chosenSummary } from './settingsModel.js';
 import { optionsCommand, storeCommand } from './settingsOptions.js';
-import { claimBooleanRows, redrawSettingRows } from '../youtube/settingComponents.js';
+import { claimBooleanRows, claimActionRows, redrawSettingRows, ROWS } from '../youtube/settingComponents.js';
 
 const BEFORE = 'SETTING_CAT_TVHTML5_LINK_PHONE';
 
@@ -28,34 +28,12 @@ function switchRow(item) {
     };
 }
 
-function choiceRow(item, path) {
-    const row = {
-        title: runs(item.title),
-        trackingParams: 'null',
-        itemId: idFor(item),
-        thumbnail: picture(item.image)
-    };
-
-    Object.defineProperty(row, 'button', {
-        enumerable: true,
-        get: () => ({
-            buttonRenderer: {
-                text: { simpleText: `${item.prefix}: ${chosenLabel(item)}` },
-                icon: { iconType: 'EDIT' },
-                trackingParams: 'null',
-                command: optionsCommand(path)
-            }
-        })
-    });
-
-    return { settingSingleOptionMenuRenderer: row };
-}
-
-function listRow(item, path) {
+function openerRow(item, path, label) {
     const row = {
         title: runs(item.title),
         summary: runs(item.summary),
         serviceEndpoint: optionsCommand(path),
+        tubeNote: item.note,
         trackingParams: 'null',
         itemId: idFor(item),
         thumbnail: picture(item.image)
@@ -63,7 +41,7 @@ function listRow(item, path) {
 
     Object.defineProperty(row, 'actionLabel', {
         enumerable: true,
-        get: () => runs(chosenSummary(item))
+        get: () => runs(label())
     });
 
     return { settingActionRenderer: row };
@@ -71,8 +49,9 @@ function listRow(item, path) {
 
 const rowFor = (item, path) =>
     item.kind === 'switch' ? switchRow(item)
-        : item.kind === 'choice' ? choiceRow(item, path)
-            : listRow(item, path);
+        : item.kind === 'choice'
+            ? openerRow(item, path, () => `${item.prefix}: ${chosenLabel(item)}`)
+            : openerRow(item, path, () => chosenSummary(item));
 
 const category = (categoryId, title, items) => ({
     settingCategoryCollectionRenderer: {
@@ -170,20 +149,25 @@ function takeMoved(items) {
 
     const taken = {};
 
-    for (let index = items.length - 1; index >= 0; index--) {
-        const found = categoryOf(items[index]);
-        if (!found || !Array.isArray(found.items)) continue;
+    const keep = (row) => {
+        const move = moveFor(row, reachable);
+        if (!move) return true;
 
-        found.items = found.items.filter((row) => {
-            const move = moveFor(row, reachable);
-            if (!move) return true;
+        (taken[move.to] = taken[move.to] || []).push({ row, move });
+        return false;
+    };
 
-            (taken[move.to] = taken[move.to] || []).push({ row, move });
-            return false;
-        });
+    // Emptied categories are removed after the walk, not during it: splicing mid-iteration skips
+    // whatever followed each removal.
+    const emptied = items.filter((item) => {
+        const found = categoryOf(item);
+        if (!found || !Array.isArray(found.items)) return false;
 
-        if (found.items.length === 0) items.splice(index, 1);
-    }
+        found.items = found.items.filter(keep);
+        return found.items.length === 0;
+    });
+
+    emptied.forEach((item) => items.splice(items.indexOf(item), 1));
 
     return taken;
 }
@@ -201,9 +185,17 @@ function putMoved(items, taken) {
     });
 }
 
+// The action row's code is only fetched when the first one is drawn, long after this response
+// is patched — so the search eases off instead of stopping, and gives up once the page is gone.
 function claimRows(attempt = 0) {
-    if (claimBooleanRows() || attempt > 20) return;
-    setTimeout(() => claimRows(attempt + 1), 250);
+    const claimed = claimBooleanRows();
+    const annotated = claimActionRows();
+    if (claimed && annotated) return;
+
+    const settling = attempt < 20;
+    if (!settling && !document.querySelector(ROWS)) return;
+
+    setTimeout(() => claimRows(attempt + 1), settling ? 250 : 500);
 }
 
 function PatchSettings(response) {

--- a/mods/ui/nativeSettings.js
+++ b/mods/ui/nativeSettings.js
@@ -147,24 +147,26 @@ function takeMoved(items) {
         if (found) reachable[found.categoryId] = true;
     });
 
-    const taken = {};
+    const categories = items.map(categoryOf).filter((found) => found && Array.isArray(found.items));
 
-    const keep = (row) => {
-        const move = moveFor(row, reachable);
-        if (!move) return true;
+    const moved = categories.reduce((all, found) => all.concat(found.items
+        .map((row) => ({ row, move: moveFor(row, reachable) }))
+        .filter((entry) => entry.move)), []);
 
-        (taken[move.to] = taken[move.to] || []).push({ row, move });
-        return false;
-    };
+    const taken = moved.reduce((byTarget, entry) => ({
+        ...byTarget,
+        [entry.move.to]: (byTarget[entry.move.to] || []).concat([entry])
+    }), {});
+
+    categories.forEach((found) => {
+        found.items = found.items.filter((row) => !moveFor(row, reachable));
+    });
 
     // Emptied categories are removed after the walk, not during it: splicing mid-iteration skips
     // whatever followed each removal.
     const emptied = items.filter((item) => {
         const found = categoryOf(item);
-        if (!found || !Array.isArray(found.items)) return false;
-
-        found.items = found.items.filter(keep);
-        return found.items.length === 0;
+        return found && Array.isArray(found.items) && found.items.length === 0;
     });
 
     emptied.forEach((item) => items.splice(items.indexOf(item), 1));
@@ -185,17 +187,22 @@ function putMoved(items, taken) {
     });
 }
 
-// The action row's code is only fetched when the first one is drawn, long after this response
-// is patched — so the search eases off instead of stopping, and gives up once the page is gone.
+const SETTLING_ATTEMPTS = 20;
+const PATIENT_ATTEMPTS = 120;
+const SETTLING_EVERY = 250;
+const PATIENT_EVERY = 500;
+
+// The action row's component loads only when the first row is drawn, after this response is patched.
 function claimRows(attempt = 0) {
     const claimed = claimBooleanRows();
     const annotated = claimActionRows();
     if (claimed && annotated) return;
 
-    const settling = attempt < 20;
+    const settling = attempt < SETTLING_ATTEMPTS;
     if (!settling && !document.querySelector(ROWS)) return;
+    if (attempt >= SETTLING_ATTEMPTS + PATIENT_ATTEMPTS) return;
 
-    setTimeout(() => claimRows(attempt + 1), settling ? 250 : 500);
+    setTimeout(() => claimRows(attempt + 1), settling ? SETTLING_EVERY : PATIENT_EVERY);
 }
 
 function PatchSettings(response) {

--- a/mods/ui/settingsModel.js
+++ b/mods/ui/settingsModel.js
@@ -26,8 +26,8 @@ const CONTRAST = 'data:image/svg+xml;charset=utf-8,'
 const Switch = (key, title, summary, image, on = true) =>
   ({ kind: 'switch', key, title, summary, image, on });
 
-const Choice = (key, title, summary, image, options, prefix) =>
-  ({ kind: 'choice', key, title, summary, image, options, prefix: prefix || title });
+const Choice = (key, title, summary, image, options, prefix, note) =>
+  ({ kind: 'choice', key, title, summary, image, options, prefix: prefix || title, note });
 
 const Set_ = (key, title, summary, image, options, invert = false) =>
   ({ kind: 'set', key, title, summary, image, options, invert });
@@ -168,7 +168,10 @@ const GROUPS = [
         SCREEN, CODECS, 'Codec'),
       Choice('speedSettingsIncrement', 'Speed steps',
         'How far one press moves playback speed in the speed control',
-        SKIPPING, INCREMENTS, 'Step')
+        SKIPPING, INCREMENTS, 'Step'),
+      Switch('rememberPlaybackSpeed', 'Remember playback speed',
+        'Carry the speed you chose into the next video. YouTube starts each one at normal '
+        + 'speed', SKIPPING)
     ]
   },
   {

--- a/mods/ui/settingsModel.js
+++ b/mods/ui/settingsModel.js
@@ -166,6 +166,8 @@ const GROUPS = [
       Choice('videoPreferredCodec', 'Preferred codec',
         'Some sets decode one codec in hardware and the rest in software',
         SCREEN, CODECS, 'Codec'),
+      Switch('reportPlaybackStats', 'Playback stats',
+        'Add the decoded frame rate and recently lost playback time to Stats for nerds', SCREEN),
       Choice('speedSettingsIncrement', 'Speed steps',
         'How far one press moves playback speed in the speed control',
         SKIPPING, INCREMENTS, 'Step'),

--- a/mods/ui/speedUI.js
+++ b/mods/ui/speedUI.js
@@ -6,6 +6,7 @@ const SPEED_KEYS = [406, 191];
 
 const MAX_SPEED = 5;
 const DEFAULT_INCREMENT = 0.25;
+const STUTTER_FIX = 1.0001;
 
 const WAIT_INTERVAL = 1000;
 
@@ -18,7 +19,7 @@ const currentRate = () => {
     return configRead('rememberPlaybackSpeed') ? configRead('videoSpeed') : 1;
 };
 
-const speedButton = (speed) => buttonItem({ title: `${speed}x` }, null, [
+const speedButton = (speed, title = `${speed}x`) => buttonItem({ title }, null, [
     { signalAction: { signal: 'POPUP_BACK' } },
     {
         setClientSettingEndpoint: {
@@ -38,20 +39,22 @@ const speedLadder = () => {
 function openSpeedOptions() {
     const rungs = speedLadder();
     const chosen = rungs.indexOf(currentRate());
+    const buttons = rungs.map((speed) => speedButton(speed))
+        .concat([speedButton(STUTTER_FIX, `Fix stuttering (${STUTTER_FIX}x)`)]);
 
     showModal(
         'Playback Speed',
-        overlayPanelItemListRenderer(rungs.map(speedButton), chosen === -1 ? 0 : chosen),
+        overlayPanelItemListRenderer(buttons, chosen === -1 ? 0 : chosen),
         'options-speed'
     );
 }
 
-const attach = (video) => {
-    video.addEventListener('canplay', () => {
-        if (!configRead('rememberPlaybackSpeed')) return;
-        video.playbackRate = configRead('videoSpeed');
-    });
+const keepSpeed = (event) => {
+    if (!(event.target instanceof window.HTMLVideoElement) || !configRead('rememberPlaybackSpeed')) return;
+    event.target.playbackRate = configRead('videoSpeed');
+};
 
+const attach = () => {
     const onKey = (event) => {
         if (SPEED_KEYS.indexOf(event.keyCode) === -1) return;
 
@@ -64,6 +67,7 @@ const attach = (video) => {
     ['keydown', 'keypress', 'keyup'].forEach((type) => document.addEventListener(type, onKey, true));
 };
 
+document.addEventListener('canplay', keepSpeed, true);
 waitFor(() => document.querySelector('video'), attach, { everyMs: WAIT_INTERVAL, forMs: Infinity });
 
 export { openSpeedOptions };

--- a/mods/ui/speedUI.js
+++ b/mods/ui/speedUI.js
@@ -2,112 +2,68 @@ import { configRead } from '../config.js';
 import { showModal, buttonItem, overlayPanelItemListRenderer } from './ytUI.js';
 import { waitFor } from '../utils/waitFor.js';
 
+const SPEED_KEYS = [406, 191];
+
+const MAX_SPEED = 5;
+const DEFAULT_INCREMENT = 0.25;
+
 const WAIT_INTERVAL = 1000;
 
-waitFor(() => document.querySelector('video'), execute_once_dom_loaded_speed,
-    { everyMs: WAIT_INTERVAL, forMs: Infinity });
+const round = (value) => Math.round(value * 100) / 100;
 
-function execute_once_dom_loaded_speed() {
-    document.querySelector('video').addEventListener('canplay', () => {
-        document.getElementsByTagName('video')[0].playbackRate = configRead('videoSpeed');;
-    });
+const currentRate = () => {
+    const video = document.querySelector('video');
+    if (video && video.playbackRate > 0) return round(video.playbackRate);
 
-    const eventHandler = (evt) => {
-        if (evt.keyCode == 406 || evt.keyCode == 191) {
-            evt.preventDefault();
-            evt.stopPropagation();
-            if (evt.type === 'keydown') {
-                openSpeedOptions();
-                return false;
-            }
-            return true;
-        };
-    }
+    return configRead('rememberPlaybackSpeed') ? configRead('videoSpeed') : 1;
+};
 
-    document.addEventListener('keydown', eventHandler, true);
-    document.addEventListener('keypress', eventHandler, true);
-    document.addEventListener('keyup', eventHandler, true);
-}
+const speedButton = (speed) => buttonItem({ title: `${speed}x` }, null, [
+    { signalAction: { signal: 'POPUP_BACK' } },
+    {
+        setClientSettingEndpoint: {
+            settingDatas: [{ clientSettingEnum: { item: 'videoSpeed' }, intValue: speed.toString() }]
+        }
+    },
+    { customAction: { action: 'SET_PLAYER_SPEED', parameters: speed.toString() } }
+]);
+
+const speedLadder = () => {
+    const increment = configRead('speedSettingsIncrement') || DEFAULT_INCREMENT;
+    const rungs = Math.floor(MAX_SPEED / increment);
+
+    return Array.from({ length: rungs }, (_, step) => round((step + 1) * increment));
+};
 
 function openSpeedOptions() {
-    const currentSpeed = configRead('videoSpeed');
-    let selectedIndex = 0;
-    const maxSpeed = 5;
-    const increment = configRead('speedSettingsIncrement') || 0.25;
-    const buttons = [];
-    for (let speed = increment; speed <= maxSpeed; speed += increment) {
-        const fixedSpeed = Math.round(speed * 100) / 100;
-        buttons.push(
-            buttonItem(
-                { title: `${fixedSpeed}x` },
-                null,
-                [
-                    {
-                        signalAction: {
-                            signal: 'POPUP_BACK'
-                        }
-                    },
-                    {
-                        setClientSettingEndpoint: {
-                            settingDatas: [
-                                {
-                                    clientSettingEnum: {
-                                        item: 'videoSpeed'
-                                    },
-                                    intValue: fixedSpeed.toString()
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        customAction: {
-                            action: 'SET_PLAYER_SPEED',
-                            parameters: fixedSpeed.toString()
-                        }
-                    }
-                ]
-            )
-        );
-        if (currentSpeed === fixedSpeed) {
-            selectedIndex = buttons.length - 1;
-        }
-    }
+    const rungs = speedLadder();
+    const chosen = rungs.indexOf(currentRate());
 
-    buttons.push(
-        buttonItem(
-            { title: 'Fix stuttering (1.0001x)' },
-            null,
-            [
-                {
-                    signalAction: {
-                        signal: 'POPUP_BACK'
-                    }
-                },
-                {
-                    setClientSettingEndpoint: {
-                        settingDatas: [
-                            {
-                                clientSettingEnum: {
-                                    item: 'videoSpeed'
-                                },
-                                intValue: '1.0001'
-                            }
-                        ]
-                    }
-                },
-                {
-                    customAction: {
-                        action: 'SET_PLAYER_SPEED',
-                        parameters: '1.0001'
-                    }
-                }
-            ]
-        )
+    showModal(
+        'Playback Speed',
+        overlayPanelItemListRenderer(rungs.map(speedButton), chosen === -1 ? 0 : chosen),
+        'options-speed'
     );
-
-    showModal('Playback Speed', overlayPanelItemListRenderer(buttons, selectedIndex), 'options-speed');
 }
 
-export {
-    openSpeedOptions
-}
+const attach = (video) => {
+    video.addEventListener('canplay', () => {
+        if (!configRead('rememberPlaybackSpeed')) return;
+        video.playbackRate = configRead('videoSpeed');
+    });
+
+    const onKey = (event) => {
+        if (SPEED_KEYS.indexOf(event.keyCode) === -1) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (event.type === 'keydown') openSpeedOptions();
+    };
+
+    ['keydown', 'keypress', 'keyup'].forEach((type) => document.addEventListener(type, onKey, true));
+};
+
+waitFor(() => document.querySelector('video'), attach, { everyMs: WAIT_INTERVAL, forMs: Infinity });
+
+export { openSpeedOptions };

--- a/mods/youtube/commands.js
+++ b/mods/youtube/commands.js
@@ -178,13 +178,36 @@ const skipWhosWatchingOnExit = (command, original, self, context) => {
     return false;
 };
 
+// The triggers that mean "before anything has been asked for", as against a locked account, a PIN
+// or an upgrade, where a real answer is needed.
+const ON_ARRIVAL = [
+    'ACCOUNT_EVENT_TRIGGER_WHOS_WATCHING',
+    'ACCOUNT_EVENT_TRIGGER_WHO_FALLBACK',
+    'ACCOUNT_EVENT_TRIGGER_APP_WELCOME',
+    'ACCOUNT_EVENT_TRIGGER_WELCOME_BACK'
+];
+
+const skipWhosWatchingOnArrival = (command) => {
+    const request = command.requestAccountSelectorCommand;
+
+    const trigger = request
+        && request.identityActionContext
+        && request.identityActionContext.eventTrigger;
+
+    if (!trigger || ON_ARRIVAL.indexOf(trigger) === -1) return PASS;
+    if (configRead('enableWhoIsWatchingMenu') || configRead('permanentlyEnableWhoIsWatchingMenu')) return PASS;
+
+    return false;
+};
+
 const INTERPRETERS = [
     applyOurSettings,
     runCustomActions,
     dressPlaybackSettings,
     forgetMiniPlayer,
     runCommandBatch,
-    skipWhosWatchingOnExit
+    skipWhosWatchingOnExit,
+    skipWhosWatchingOnArrival
 ];
 
 const interceptCommands = () => {

--- a/mods/youtube/internals.js
+++ b/mods/youtube/internals.js
@@ -36,21 +36,16 @@ const findByPrototype = (matches) => {
     return match ? match[1] : null;
 };
 
-const nameOf = (target) => {
-    const match = entries().find(([, value]) => value === target);
-    return match ? match[0] : null;
+// `S` is the component's custom-element name; survives releases that rename the export.
+const findComponent = (tag) => {
+    const match = entries().find(([, value]) => typeof value === 'function' && value.S === tag);
+    return match ? match[1] : null;
 };
 
 // Several settings live in Maps parked in the registry, found by a key only they carry.
 const findMap = (key) => {
     const match = entries().find(([, value]) => value instanceof Map && value.has(key));
     return match ? match[1] : null;
-};
-
-const replace = (target, replacement) => {
-    const name = nameOf(target);
-    if (name) registry()[name] = replacement;
-    return !!name;
 };
 
 const findResolver = () => {
@@ -119,4 +114,4 @@ const reloadGuide = () => {
     if (run) run('reloadGuideAction');
 };
 
-export { findBySource, findByPrototype, findMap, nameOf, replace, findResolver, resolve, findActionRunner, reloadGuide, sourceOf };
+export { findBySource, findByPrototype, findComponent, findMap, findResolver, resolve, findActionRunner, reloadGuide, sourceOf };

--- a/mods/youtube/settingComponents.js
+++ b/mods/youtube/settingComponents.js
@@ -1,5 +1,5 @@
 import { configRead } from '../config.js';
-import { findByPrototype, sourceOf } from './internals.js';
+import { findByPrototype, findBySource, findComponent, sourceOf } from './internals.js';
 
 const getterOf = (prototype, name) => {
     const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
@@ -23,10 +23,10 @@ const settingOf = (endpoint) => {
     return configRead(key) === undefined ? null : { key, on: data.boolValue };
 };
 
-let claimed = false;
+const state = { booleans: false, notes: false, redrawName: null };
 
 function claimBooleanRows() {
-    if (claimed) return true;
+    if (state.booleans) return true;
 
     const component = findBooleanRow();
     if (!component) return false;
@@ -44,7 +44,61 @@ function claimBooleanRows() {
         }
     });
 
-    claimed = true;
+    state.booleans = true;
+    return true;
+}
+
+const ACTION_ROW = 'ytlr-setting-action-renderer';
+
+// Action rows have no footer template; wFmJpd/vAMQc are YouTube's own note classes. Nodes are
+// stamped with a private symbol when built, so the footer must come from YouTube's hyperscript.
+const findHyperscript = () => findBySource('.type=', '.props=', '.children=');
+
+const noteFor = (H, note) => H(
+    'div',
+    { className: 'wFmJpd', idomKey: 'tube-note' },
+    H('div', { className: 'vAMQc', 'aria-label': note }, note)
+);
+
+const withNote = (original, H) => function withTubeNote(props, rowState) {
+    const tree = original.call(this, props, rowState);
+    const note = props && props.data && props.data.tubeNote;
+
+    if (note && tree && Array.isArray(tree.children)) tree.children.push(noteFor(H, note));
+
+    return tree;
+};
+
+// `template` is assigned per instance in the constructor, so the wrap has to be an accessor.
+function claimActionRows() {
+    if (state.notes) return true;
+
+    const component = findComponent(ACTION_ROW);
+    if (!component) return false;
+
+    const H = findHyperscript();
+    if (!H) return false;
+
+    Object.defineProperty(component.prototype, 'template', {
+        configurable: true,
+        get: function () { return this.tubeTemplate; },
+        set: function (original) { this.tubeTemplate = withNote(original, H); }
+    });
+
+    // Rows already on screen were built before the accessor existed; reassigning makes it fire.
+    const restamp = (row) => {
+        const instance = row.__instance;
+        if (!instance || !Object.prototype.hasOwnProperty.call(instance, 'template')) return;
+
+        const original = instance.template;
+        delete instance.template;
+        instance.template = original;
+    };
+
+    Array.from(document.querySelectorAll(ACTION_ROW)).forEach(restamp);
+
+    state.notes = true;
+    redrawSettingRows();
     return true;
 }
 
@@ -54,40 +108,39 @@ const ROWS = [
     'ytlr-setting-action-renderer'
 ].join(',');
 
-let redrawName = null;
+const redrawsFrom = (prototype) => Object.getOwnPropertyNames(prototype).find((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+    const method = descriptor && descriptor.value;
+    if (typeof method !== 'function' || method.length !== 0) return false;
+
+    const source = sourceOf(method);
+    return source.indexOf('this.state') !== -1 && source.indexOf('Object.assign') === -1;
+});
 
 const findRedraw = (instance) => {
-    let prototype = Object.getPrototypeOf(instance);
+    const walk = (prototype) => {
+        if (!prototype || prototype === Object.prototype) return null;
 
-    while (prototype && prototype !== Object.prototype) {
-        const name = Object.getOwnPropertyNames(prototype).find((key) => {
-            const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
-            const method = descriptor && descriptor.value;
-            if (typeof method !== 'function' || method.length !== 0) return false;
+        return redrawsFrom(prototype) || walk(Object.getPrototypeOf(prototype));
+    };
 
-            const source = sourceOf(method);
-            return source.indexOf('this.state') !== -1 && source.indexOf('Object.assign') === -1;
-        });
-
-        if (name) return name;
-        prototype = Object.getPrototypeOf(prototype);
-    }
-
-    return null;
+    return walk(Object.getPrototypeOf(instance));
 };
 
 function redrawSettingRows() {
-    const rows = document.querySelectorAll(ROWS);
+    // The name is found once and remembered: locating it reads the source of every method on the
+    // prototype chain.
+    const redraw = (row) => {
+        const instance = row.__instance;
+        if (!instance) return;
 
-    for (let index = 0; index < rows.length; index++) {
-        const instance = rows[index].__instance;
-        if (!instance) continue;
+        if (!state.redrawName) state.redrawName = findRedraw(instance);
 
-        if (!redrawName) redrawName = findRedraw(instance);
+        const method = state.redrawName && instance[state.redrawName];
+        if (typeof method === 'function') method.call(instance);
+    };
 
-        const redraw = redrawName && instance[redrawName];
-        if (typeof redraw === 'function') redraw.call(instance);
-    }
+    Array.from(document.querySelectorAll(ROWS)).forEach(redraw);
 }
 
-export { claimBooleanRows, redrawSettingRows };
+export { claimBooleanRows, claimActionRows, redrawSettingRows, ROWS };

--- a/mods/youtube/settingComponents.js
+++ b/mods/youtube/settingComponents.js
@@ -50,8 +50,7 @@ function claimBooleanRows() {
 
 const ACTION_ROW = 'ytlr-setting-action-renderer';
 
-// Action rows have no footer template; wFmJpd/vAMQc are YouTube's own note classes. Nodes are
-// stamped with a private symbol when built, so the footer must come from YouTube's hyperscript.
+// Nodes carry a private stamp, so the note must be built with YouTube's own hyperscript.
 const findHyperscript = () => findBySource('.type=', '.props=', '.children=');
 
 const noteFor = (H, note) => H(


### PR DESCRIPTION
Two things were unanswerable from the couch. Whether a video is dropping frames:
`getVideoPlaybackQuality` is there, nothing read it, and judder is the kind of
fault that is argued about rather than measured. And whether the preferred
quality was honoured: the setting asked for a resolution the stream did not
offer and then said nothing, so "1080p" on a video that tops out at 720p looked
like the setting being ignored.

So `playbackStats.js` samples the video element and puts dropped frames,
resolution, codec and buffer health on screen, behind `reportPlaybackStats`.
`quality.js` holds the choosing — highest, or the asked-for line, or the best
one below it when that line is not offered — as two pure functions with tests,
so the rule can be read without a television. `preferredVideoQuality.js` becomes
the part that talks to the player: it retries a bounded number of times, and
stops asking once the answer is the best on offer rather than asking for ever.

The settings rows that expose both come with it, and `speedUI` gains
`rememberPlaybackSpeed` — a speed set for one video was being carried into every
video after it, which is not what anyone meant by it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>