### PR TITLE
Terminate TLS here, so the page keeps its real origin

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,10 @@ proxying, no rewriting. With it off, youtube.com is proxied through
 `localhost:8099` so a plain script tag can inject instead. The page is then
 plain HTTP, so the `__Secure-` / `__Host-` cookie prefixes are renamed, and
 requests to the Google hosts that will not answer that origin go through the
-service's `/cors-bypass/` route.
+service's `/cors-bypass/` route. Used as a forward proxy instead, the service
+tunnels CONNECT and, once key material exists, terminates TLS for YouTube's and
+Google's hosts itself, so the page keeps its real origin: cookies pass untouched
+and YouTube's CSP stays, with the injected tags carrying its nonce.
 
 **One bundle.** Polyfills in a browser bundle are parsed on *every* launch, and
 the sets that needed them are gone: the floor is Chrome 63, so the ES5 downlevel,
@@ -145,6 +148,10 @@ looking at it needs a stand-in that answers and never hands over. That is
 | `service/index.js` | Routes, and the once-per-launch update check |
 | `service/lib/injector.js` | CDP injection over loopback sdb |
 | `service/lib/proxy.js` | Script injection, cookie renaming, and `/cors-bypass/` |
+| `service/lib/forward.js` | Forward-proxy requests and the CONNECT tunnel |
+| `service/lib/mitm.js` | TLS termination for YouTube's and Google's hosts |
+| `service/lib/bigheaders.js` | The HTTP/2 refetch for headers too big for HTTP/1 |
+| `service/lib/x509.js` | The certificate issuer |
 | `service/lib/loader.js` | Which bundle a TV runs, and from where |
 | `service/lib/ports.js` | 8099 proxy, 8097 dev |
 | `ui/src/boot.js` | The boot screen, which exists to disappear |

--- a/service/index.js
+++ b/service/index.js
@@ -7,6 +7,7 @@ const ports = require('./lib/ports.js');
 const loader = require('./lib/loader.js');
 const proxy = require('./lib/proxy.js');
 const devbridge = require('./lib/devbridge.js');
+const forward = require('./lib/forward.js');
 
 const isTV = typeof tizen !== 'undefined';
 
@@ -142,7 +143,7 @@ function announceReady() {
 
 const BIND = process.env.TUBE_PROXY_HOST ? '0.0.0.0' : '127.0.0.1';
 
-app.listen(ports.PROXY, BIND, () => {
+const server = app.listen(ports.PROXY, BIND, () => {
     console.log(`tube service on 127.0.0.1:${ports.PROXY}`);
     if (!isTV) {
         console.log('Running off-TV: proxy and userscript are live.');
@@ -150,5 +151,9 @@ app.listen(ports.PROXY, BIND, () => {
 
     announceReady();
 });
+
+// A forward proxy sends TLS through CONNECT; without an answer to that a client pointed here has
+// no network at all.
+forward.tunnel(server);
 
 setTimeout(maybeCheckForUpdate, 5000);

--- a/service/lib/bigheaders.js
+++ b/service/lib/bigheaders.js
@@ -1,0 +1,132 @@
+'use strict';
+
+// An upstream fetch that survives YouTube's response headers.
+//
+// Node caps the response header block at 8KB on Node 12 and 16KB from Node 14, and cannot be
+// told otherwise from inside the process. YouTube's answer to a Cobalt client is 16.3KB, almost
+// all of it one content-security-policy carrying Cobalt's own source expressions. HTTP/2 carries
+// headers in HPACK, where the limit is an order of magnitude higher.
+
+const http2 = require('http2');
+const zlib = require('zlib');
+const { PassThrough } = require('stream');
+const URL = require('url');
+
+const SESSION_IDLE = 30000;
+const REQUEST_TIMEOUT = 30000;
+const MAX_HEADER_LIST = 262144;
+
+const ILLEGAL_IN_H2 = ['connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade', 'host'];
+
+// One session per origin, closed when idle: a session per request would cost a handshake apiece.
+const sessions = new Map();
+
+const sessionFor = (origin) => {
+    const existing = sessions.get(origin);
+    if (existing && !existing.closed && !existing.destroyed) return existing;
+
+    const session = http2.connect(origin, { settings: { maxHeaderListSize: MAX_HEADER_LIST } });
+
+    session.setTimeout(SESSION_IDLE, () => session.close());
+    session.on('error', () => sessions.delete(origin));
+    session.on('close', () => sessions.delete(origin));
+
+    sessions.set(origin, session);
+    return session;
+};
+
+// node-fetch's Response in the shapes the proxy uses: headers.raw(), headers.get(), a readable
+// body and text().
+const responseOf = (status, received, stream) => {
+    const raw = Object.keys(received).reduce((all, name) => {
+        if (name[0] === ':') return all;                    // h2 pseudo-headers are not real headers
+
+        const value = received[name];
+        return Object.assign(all, { [name]: Array.isArray(value) ? value : [String(value)] });
+    }, {});
+
+    const text = () => new Promise((resolve, reject) => {
+        const parts = [];
+
+        stream.on('data', (chunk) => parts.push(chunk));
+        stream.on('end', () => resolve(Buffer.concat(parts).toString('utf8')));
+        stream.on('error', reject);
+    });
+
+    return {
+        status,
+        ok: status >= 200 && status < 300,
+        body: stream,
+        headers: {
+            raw: () => raw,
+            get: (name) => {
+                const found = raw[String(name).toLowerCase()];
+                return found ? found.join(', ') : null;
+            }
+        },
+        text
+    };
+};
+
+// node-fetch decompresses and this does not, which is a difference that does not announce
+// itself: the body arrives gzipped, is treated as text because the type says html, has a script
+// injected into the middle of it and is served as a loaded page behind a black screen.
+const decoded = (request, encoding) => {
+    const out = new PassThrough();
+    const decoder = encoding === 'gzip' ? zlib.createGunzip()
+        : (encoding === 'deflate' ? zlib.createInflate() : null);
+
+    request.on('error', (error) => out.destroy(error));
+
+    if (!decoder) {
+        request.pipe(out);
+        return out;
+    }
+
+    decoder.on('error', (error) => out.destroy(error));
+    request.pipe(decoder).pipe(out);
+
+    return out;
+};
+
+const fetchOverHttp2 = (target, options) => new Promise((resolve, reject) => {
+    const parsed = URL.parse(target);
+    if (!parsed.host) return reject(new Error(`not a URL this can fetch: ${target}`));
+
+    const session = sessionFor(`https://${parsed.host}`);
+
+    const headers = ILLEGAL_IN_H2.reduce((all, name) => {
+        delete all[name];
+        return all;
+    }, Object.assign({}, options.headers));
+
+    const request = session.request(Object.assign({
+        ':method': options.method || 'GET',
+        ':path': parsed.path || '/',
+        ':authority': parsed.host,
+        ':scheme': 'https'
+    }, headers));
+
+    request.setTimeout(REQUEST_TIMEOUT, () => request.destroy(new Error('http2 request timed out')));
+    request.on('error', reject);
+
+    request.on('response', (received) => {
+        // Whatever is handed on is identity-encoded now, so the headers must not claim otherwise.
+        const announced = Object.assign({}, received);
+        delete announced['content-encoding'];
+        delete announced['content-length'];
+
+        resolve(responseOf(
+            Number(received[':status']) || 502,
+            announced,
+            decoded(request, String(received['content-encoding'] || '').toLowerCase())
+        ));
+    });
+
+    return Buffer.isBuffer(options.body) ? request.end(options.body) : request.end();
+});
+
+const isHeaderOverflow = (error) => !!error
+    && (error.code === 'HPE_HEADER_OVERFLOW' || /header overflow/i.test(error.message || ''));
+
+module.exports = { fetchOverHttp2, isHeaderOverflow };

--- a/service/lib/bigheaders.js
+++ b/service/lib/bigheaders.js
@@ -1,11 +1,6 @@
 'use strict';
 
-// An upstream fetch that survives YouTube's response headers.
-//
-// Node caps the response header block at 8KB on Node 12 and 16KB from Node 14, and cannot be
-// told otherwise from inside the process. YouTube's answer to a Cobalt client is 16.3KB, almost
-// all of it one content-security-policy carrying Cobalt's own source expressions. HTTP/2 carries
-// headers in HPACK, where the limit is an order of magnitude higher.
+// Refetches over HTTP/2 a response whose header block overflows Node's HTTP/1 parser.
 
 const http2 = require('http2');
 const zlib = require('zlib');
@@ -26,10 +21,11 @@ const sessionFor = (origin) => {
     if (existing && !existing.closed && !existing.destroyed) return existing;
 
     const session = http2.connect(origin, { settings: { maxHeaderListSize: MAX_HEADER_LIST } });
+    const forget = () => { if (sessions.get(origin) === session) sessions.delete(origin); };
 
     session.setTimeout(SESSION_IDLE, () => session.close());
-    session.on('error', () => sessions.delete(origin));
-    session.on('close', () => sessions.delete(origin));
+    session.on('error', forget);
+    session.on('close', forget);
 
     sessions.set(origin, session);
     return session;
@@ -38,18 +34,15 @@ const sessionFor = (origin) => {
 // node-fetch's Response in the shapes the proxy uses: headers.raw(), headers.get(), a readable
 // body and text().
 const responseOf = (status, received, stream) => {
-    const raw = Object.keys(received).reduce((all, name) => {
-        if (name[0] === ':') return all;                    // h2 pseudo-headers are not real headers
-
-        const value = received[name];
-        return Object.assign(all, { [name]: Array.isArray(value) ? value : [String(value)] });
-    }, {});
+    const raw = Object.fromEntries(Object.keys(received)
+        .filter((name) => name[0] !== ':')
+        .map((name) => [name, Array.isArray(received[name]) ? received[name] : [String(received[name])]]));
 
     const text = () => new Promise((resolve, reject) => {
-        const parts = [];
+        const held = { parts: [] };
 
-        stream.on('data', (chunk) => parts.push(chunk));
-        stream.on('end', () => resolve(Buffer.concat(parts).toString('utf8')));
+        stream.on('data', (chunk) => { held.parts = held.parts.concat([chunk]); });
+        stream.on('end', () => resolve(Buffer.concat(held.parts).toString('utf8')));
         stream.on('error', reject);
     });
 
@@ -68,9 +61,7 @@ const responseOf = (status, received, stream) => {
     };
 };
 
-// node-fetch decompresses and this does not, which is a difference that does not announce
-// itself: the body arrives gzipped, is treated as text because the type says html, has a script
-// injected into the middle of it and is served as a loaded page behind a black screen.
+// Decoded as node-fetch would, because the proxy treats the body as text.
 const decoded = (request, encoding) => {
     const out = new PassThrough();
     const decoder = encoding === 'gzip' ? zlib.createGunzip()
@@ -95,10 +86,8 @@ const fetchOverHttp2 = (target, options) => new Promise((resolve, reject) => {
 
     const session = sessionFor(`https://${parsed.host}`);
 
-    const headers = ILLEGAL_IN_H2.reduce((all, name) => {
-        delete all[name];
-        return all;
-    }, Object.assign({}, options.headers));
+    const headers = Object.fromEntries(Object.entries(options.headers || {})
+        .filter(([name]) => ILLEGAL_IN_H2.indexOf(name) === -1));
 
     const request = session.request(Object.assign({
         ':method': options.method || 'GET',
@@ -112,9 +101,8 @@ const fetchOverHttp2 = (target, options) => new Promise((resolve, reject) => {
 
     request.on('response', (received) => {
         // Whatever is handed on is identity-encoded now, so the headers must not claim otherwise.
-        const announced = Object.assign({}, received);
-        delete announced['content-encoding'];
-        delete announced['content-length'];
+        const announced = Object.fromEntries(Object.entries(received)
+            .filter(([name]) => name !== 'content-encoding' && name !== 'content-length'));
 
         resolve(responseOf(
             Number(received[':status']) || 502,

--- a/service/lib/forward.js
+++ b/service/lib/forward.js
@@ -1,56 +1,18 @@
 'use strict';
 
-// Cobalt's --proxy speaks the forward-proxy form: an absolute URI on the request line for plain
-// HTTP, and CONNECT for TLS. Answering both lets the container's networking come through the
-// service with nothing in the page rewritten.
+// Answers Cobalt's --proxy: absolute-URI requests for plain HTTP and CONNECT for TLS.
 
 const net = require('net');
-const tls = require('tls');
-const fs = require('fs');
 const URL = require('url');
 
 const journal = require('./journal.js');
 const postmortem = require('./postmortem.js');
-
-// Guarded for the same reason as in index.js: interception is an extra, and a module that will
-// not load here must cost the MITM, never the tunnel.
-function cobaltIfItLoads() {
-    try {
-        return require('./cobalt.js');
-    } catch (e) {
-        postmortem.note('cobalt', `module would not load: ${postmortem.describe(e)}`);
-        return null;
-    }
-}
-
-const cobalt = cobaltIfItLoads();
+const mitm = require('./mitm.js');
 
 const ABSOLUTE = /^https?:\/\//i;
 
-const INTERCEPTED = ['youtube.com', 'googleapis.com', 'google.com', 'gstatic.com', 'ggpht.com'];
-
-const RETRY_MATERIAL_EVERY = 3000;
 const QUIET = 60000;
 const MOST_REMEMBERED = 200;
-
-// The material is made on the set rather than shipped, so it may not exist when the first
-// connection arrives — key generation takes seconds on this hardware. Until it does every host is
-// tunnelled through untouched, which is a working television showing stock YouTube. A `disabled`
-// file beside the keys forces that state permanently.
-const mitmConfig = () => {
-    if (!cobalt) return null;
-
-    try {
-        return fs.existsSync(`${cobalt.MITM_DIR}/disabled`) ? null : cobalt.material();
-    } catch (e) {
-        return null;
-    }
-};
-
-const mitmHost = (host) => {
-    const name = String(host || '').split(':')[0].toLowerCase();
-    return INTERCEPTED.some((domain) => name === domain || name.endsWith(`.${domain}`));
-};
 
 const absoluteTarget = (url) => (ABSOLUTE.test(url) ? url : null);
 
@@ -63,20 +25,16 @@ const ourHosts = (host, port) => [
 // Turns "GET http://us:8099/tv" back into "GET /tv" so the routes see what they expect.
 const normaliseSelf = (req, host, port) => {
     const target = absoluteTarget(req.url);
-    if (!target) return false;
+    if (!target) return;
 
     const parsed = URL.parse(target);
-    if (ourHosts(host, port).indexOf(parsed.host) === -1) return false;
+    if (ourHosts(host, port).indexOf(parsed.host) === -1) return;
 
     req.url = parsed.path || '/';
-    return true;
 };
 
 const tunnel = (server) => {
-    // The container never opens the dev bridge, so whether the handshake was accepted is the whole
-    // question and the in-memory journal cannot answer it. Deduplicated for a minute — long enough
-    // to collapse one launch, short enough that the next launch says so. Suppressing repeats for
-    // the life of the process reads as though nothing happened at all.
+    // Repeats are dropped for a minute, so one launch logs each outcome once.
     const seen = new Map();
 
     const record = (topic, detail) => {
@@ -90,42 +48,11 @@ const tunnel = (server) => {
         postmortem.note('mitm', key);
     };
 
-    // Built on the first connection that could use it rather than at start-up, and retried if the
-    // material was still being made then.
-    const held = { mitm: null, asked: 0 };
-
-    const interceptor = () => {
-        if (held.mitm) return held.mitm;
-        if (Date.now() - held.asked < RETRY_MATERIAL_EVERY) return null;
-        held.asked = Date.now();
-
-        const config = mitmConfig();
-        if (!config) return null;
-
-        const mitm = tls.createServer(config, (socket) => {
-            // Feed decrypted HTTP into the existing Express application. The marker lets the
-            // fallback preserve the original Host instead of assuming www.youtube.com.
-            socket.__tubeMitm = true;
-            journal.service('mitm', `secure ${socket.servername || '?'}`);
-            record('accepted', socket.servername || '?');
-            server.emit('connection', socket);
-        });
-
-        mitm.on('tlsClientError', (error, socket) => {
-            journal.service('mitm', `tls error ${error.message}`);
-            record('refused', error.message);
-            socket.destroy();
-        });
-
-        mitm.on('error', (error) => record('listener', postmortem.describe(error)));
-
-        held.mitm = mitm;
-        return mitm;
-    };
+    const interceptor = mitm.interceptor(server, record);
 
     server.on('connect', (req, client, head) => {
         const [host, port] = req.url.split(':');
-        const secure = mitmHost(host) ? interceptor() : null;
+        const secure = mitm.isIntercepted(host) ? interceptor() : null;
 
         if (secure) {
             client.on('error', () => client.destroy());
@@ -136,8 +63,6 @@ const tunnel = (server) => {
             secure.emit('connection', client);
             return;
         }
-
-        const carried = { bytes: 0 };
 
         const upstream = net.connect(Number(port) || 443, host, () => {
             client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
@@ -159,8 +84,7 @@ const tunnel = (server) => {
 
         if (journal.wanted()) {
             journal.service('tunnel', `open ${req.url}`);
-            upstream.on('data', (chunk) => { carried.bytes += chunk.length; });
-            client.on('close', () => journal.service('tunnel', `shut ${req.url} after ${carried.bytes}b`));
+            client.on('close', () => journal.service('tunnel', `shut ${req.url} after ${upstream.bytesRead}b`));
         }
 
         upstream.on('error', drop);

--- a/service/lib/forward.js
+++ b/service/lib/forward.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// Cobalt's --proxy speaks the forward-proxy form: an absolute URI on the request line for plain
+// HTTP, and CONNECT for TLS. Answering both lets the container's networking come through the
+// service with nothing in the page rewritten.
+
+const net = require('net');
+const tls = require('tls');
+const fs = require('fs');
+const URL = require('url');
+
+const journal = require('./journal.js');
+const postmortem = require('./postmortem.js');
+
+// Guarded for the same reason as in index.js: interception is an extra, and a module that will
+// not load here must cost the MITM, never the tunnel.
+function cobaltIfItLoads() {
+    try {
+        return require('./cobalt.js');
+    } catch (e) {
+        postmortem.note('cobalt', `module would not load: ${postmortem.describe(e)}`);
+        return null;
+    }
+}
+
+const cobalt = cobaltIfItLoads();
+
+const ABSOLUTE = /^https?:\/\//i;
+
+const INTERCEPTED = ['youtube.com', 'googleapis.com', 'google.com', 'gstatic.com', 'ggpht.com'];
+
+const RETRY_MATERIAL_EVERY = 3000;
+const QUIET = 60000;
+const MOST_REMEMBERED = 200;
+
+// The material is made on the set rather than shipped, so it may not exist when the first
+// connection arrives — key generation takes seconds on this hardware. Until it does every host is
+// tunnelled through untouched, which is a working television showing stock YouTube. A `disabled`
+// file beside the keys forces that state permanently.
+const mitmConfig = () => {
+    if (!cobalt) return null;
+
+    try {
+        return fs.existsSync(`${cobalt.MITM_DIR}/disabled`) ? null : cobalt.material();
+    } catch (e) {
+        return null;
+    }
+};
+
+const mitmHost = (host) => {
+    const name = String(host || '').split(':')[0].toLowerCase();
+    return INTERCEPTED.some((domain) => name === domain || name.endsWith(`.${domain}`));
+};
+
+const absoluteTarget = (url) => (ABSOLUTE.test(url) ? url : null);
+
+// Cobalt drops the port when it rebuilds a URL out of INNERTUBE_HOST_OVERRIDE, so requests arrive
+// naming us on port 80; forwarding those reaches nothing.
+const ourHosts = (host, port) => [
+    `${host}:${port}`, host, 'localhost', `localhost:${port}`, '127.0.0.1', `127.0.0.1:${port}`
+];
+
+// Turns "GET http://us:8099/tv" back into "GET /tv" so the routes see what they expect.
+const normaliseSelf = (req, host, port) => {
+    const target = absoluteTarget(req.url);
+    if (!target) return false;
+
+    const parsed = URL.parse(target);
+    if (ourHosts(host, port).indexOf(parsed.host) === -1) return false;
+
+    req.url = parsed.path || '/';
+    return true;
+};
+
+const tunnel = (server) => {
+    // The container never opens the dev bridge, so whether the handshake was accepted is the whole
+    // question and the in-memory journal cannot answer it. Deduplicated for a minute — long enough
+    // to collapse one launch, short enough that the next launch says so. Suppressing repeats for
+    // the life of the process reads as though nothing happened at all.
+    const seen = new Map();
+
+    const record = (topic, detail) => {
+        const key = `${topic} ${detail}`;
+        const now = Date.now();
+
+        if (seen.get(key) > now - QUIET) return;
+        if (seen.size > MOST_REMEMBERED) seen.clear();
+
+        seen.set(key, now);
+        postmortem.note('mitm', key);
+    };
+
+    // Built on the first connection that could use it rather than at start-up, and retried if the
+    // material was still being made then.
+    const held = { mitm: null, asked: 0 };
+
+    const interceptor = () => {
+        if (held.mitm) return held.mitm;
+        if (Date.now() - held.asked < RETRY_MATERIAL_EVERY) return null;
+        held.asked = Date.now();
+
+        const config = mitmConfig();
+        if (!config) return null;
+
+        const mitm = tls.createServer(config, (socket) => {
+            // Feed decrypted HTTP into the existing Express application. The marker lets the
+            // fallback preserve the original Host instead of assuming www.youtube.com.
+            socket.__tubeMitm = true;
+            journal.service('mitm', `secure ${socket.servername || '?'}`);
+            record('accepted', socket.servername || '?');
+            server.emit('connection', socket);
+        });
+
+        mitm.on('tlsClientError', (error, socket) => {
+            journal.service('mitm', `tls error ${error.message}`);
+            record('refused', error.message);
+            socket.destroy();
+        });
+
+        mitm.on('error', (error) => record('listener', postmortem.describe(error)));
+
+        held.mitm = mitm;
+        return mitm;
+    };
+
+    server.on('connect', (req, client, head) => {
+        const [host, port] = req.url.split(':');
+        const secure = mitmHost(host) ? interceptor() : null;
+
+        if (secure) {
+            client.on('error', () => client.destroy());
+            client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+            if (head && head.length) client.unshift(head);
+
+            journal.service('mitm', `open ${req.url}`);
+            secure.emit('connection', client);
+            return;
+        }
+
+        const carried = { bytes: 0 };
+
+        const upstream = net.connect(Number(port) || 443, host, () => {
+            client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+            if (head && head.length) upstream.write(head);
+
+            upstream.pipe(client);
+            client.pipe(upstream);
+        });
+
+        const drop = (error) => {
+            if (error) {
+                journal.service('tunnel', `broke ${req.url}: ${error.message}`);
+                record('tunnel', `${req.url} ${error.code || error.message}`);
+            }
+
+            upstream.destroy();
+            client.destroy();
+        };
+
+        if (journal.wanted()) {
+            journal.service('tunnel', `open ${req.url}`);
+            upstream.on('data', (chunk) => { carried.bytes += chunk.length; });
+            client.on('close', () => journal.service('tunnel', `shut ${req.url} after ${carried.bytes}b`));
+        }
+
+        upstream.on('error', drop);
+        client.on('error', drop);
+    });
+};
+
+module.exports = { absoluteTarget, normaliseSelf, tunnel };

--- a/service/lib/mitm.js
+++ b/service/lib/mitm.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const tls = require('tls');
+const fs = require('fs');
+
+const journal = require('./journal.js');
+const postmortem = require('./postmortem.js');
+
+// A cobalt.js that fails to load disables interception, never the tunnel.
+function cobaltIfItLoads() {
+    try {
+        return require('./cobalt.js');
+    } catch (e) {
+        postmortem.note('cobalt', `module would not load: ${postmortem.describe(e)}`);
+        return null;
+    }
+}
+
+const cobalt = cobaltIfItLoads();
+
+const INTERCEPTED = ['youtube.com', 'googleapis.com', 'google.com', 'gstatic.com', 'ggpht.com'];
+
+const RETRY_MATERIAL_EVERY = 3000;
+
+// Every host is tunnelled untouched until the key material exists, and for good while a
+// `disabled` file sits beside it.
+const mitmConfig = () => {
+    if (!cobalt) return null;
+
+    try {
+        return fs.existsSync(`${cobalt.MITM_DIR}/disabled`) ? null : cobalt.material();
+    } catch (e) {
+        return null;
+    }
+};
+
+const isIntercepted = (host) => {
+    const name = String(host || '').split(':')[0].toLowerCase();
+    return INTERCEPTED.some((domain) => name === domain || name.endsWith(`.${domain}`));
+};
+
+const interceptor = (server, record) => {
+    const held = { mitm: null, asked: 0 };
+
+    const secureServer = (config) => {
+        try {
+            return tls.createServer(config, (socket) => {
+                journal.service('mitm', `secure ${socket.servername || '?'}`);
+                record('accepted', socket.servername || '?');
+                server.emit('connection', socket);
+            });
+        } catch (e) {
+            return null;
+        }
+    };
+
+    return () => {
+        if (held.mitm) return held.mitm;
+        if (Date.now() - held.asked < RETRY_MATERIAL_EVERY) return null;
+        held.asked = Date.now();
+
+        const config = mitmConfig();
+        const mitm = config ? secureServer(config) : null;
+        if (!mitm) return null;
+
+        mitm.on('tlsClientError', (error, socket) => {
+            journal.service('mitm', `tls error ${error.message}`);
+            record('refused', error.message);
+            socket.destroy();
+        });
+
+        mitm.on('error', (error) => record('listener', postmortem.describe(error)));
+
+        held.mitm = mitm;
+        return mitm;
+    };
+};
+
+module.exports = { INTERCEPTED, isIntercepted, interceptor };

--- a/service/lib/proxy.js
+++ b/service/lib/proxy.js
@@ -9,8 +9,10 @@ const { readFileSync } = require('fs');
 
 const ports = require('./ports.js');
 const loader = require('./loader.js');
+const forward = require('./forward.js');
 const journal = require('./journal.js');
 const postmortem = require('./postmortem.js');
+const bigheaders = require('./bigheaders.js');
 
 const AGENT_OPTIONS = { keepAlive: true, keepAliveMsecs: 15000 };
 const httpsAgent = new https.Agent(AGENT_OPTIONS);
@@ -21,9 +23,8 @@ const DEV_USER_AGENT = process.env.TUBE_DEV_UA || '';
 const DEV_INJECT_PATH = process.env.TUBE_DEV_INJECT || '';
 
 const TEXTUAL = ['text/html', 'application/json', 'javascript', 'text/css'];
-const STRIPPED_HEADERS = [
-    'content-encoding', 'content-length', 'transfer-encoding', 'content-security-policy', 'alt-svc'
-];
+const STRIPPED_HEADERS = ['content-encoding', 'content-length', 'transfer-encoding', 'alt-svc'];
+const CSP_HEADER = 'content-security-policy';
 const BODIED = ['POST', 'PUT', 'PATCH'];
 
 const YOUTUBE_HOST = 'www.youtube.com';
@@ -35,10 +36,18 @@ const RETRIABLE = ['ECONNRESET', 'EPIPE', 'ETIMEDOUT'];
 
 const GOOGLE = /(^|\.)(youtube\.com|googlevideo\.com|googleapis\.com|google\.com|ggpht\.com|gstatic\.com|googleusercontent\.com)$/;
 
+// How many intercepted requests to write to the log on disk before falling quiet: inside the
+// container there is no console and no dev bridge, and a working page makes hundreds.
+const TRACE_LIMIT = 40;
+
+const state = { traced: 0 };
+
 const PROXY_HOST = process.env.TUBE_PROXY_HOST || 'localhost';
 
 const localOrigin = () => `http://${PROXY_HOST}:${ports.PROXY}`;
 const proxyPrefix = () => `${localOrigin()}/cors-bypass/`;
+
+const interceptedTls = (req) => !!(req.socket && (req.socket.__tubeMitm || req.socket.encrypted));
 
 const flagOverrides = new Map();
 
@@ -48,6 +57,8 @@ const upstream = {
     onesie: 'auto',
     nativeProxyPatches: true
 };
+
+const nonceOf = (policy) => (/'nonce-([A-Za-z0-9+/_-]+)'/.exec(policy || '') || [])[1] || null;
 
 const spoofUserAgent = (text) => {
     const shim = '<script>try{Object.defineProperty(navigator,"userAgent",'
@@ -105,7 +116,7 @@ const retuneFlags = (text) => text.replace(BLOB, (whole, lead, blob) => (
     `${lead}${Array.from(flagOverrides).reduce(retuneFlag, blob)}`
 ));
 
-const rewriteBody = (text, url) => {
+const rewriteBody = (text, url, injectionOrigin, nonce) => {
     if (url.indexOf('/tv') !== 0 || url.indexOf('/tv_config') !== -1) return text;
 
     const tuned = [
@@ -114,10 +125,13 @@ const rewriteBody = (text, url) => {
         upstream.nativeProxyPatches ? null : overrideInnertubeHost
     ].filter(Boolean).reduce((out, step) => step(out), text);
 
-    const origin = localOrigin();
+    // The nonce is quoted from the page's own script-src — without it the injected tags are
+    // refused by the nonce policy YouTube serves a Cobalt client.
+    const stamp = nonce ? ` nonce="${nonce}"` : '';
+    const origin = injectionOrigin || localOrigin();
 
-    const tag = `<script>window.__TUBE_NATIVE_PROXY_PATCHES__=${upstream.nativeProxyPatches};</script>`
-        + `<script src="${origin}/__tube/userScript.js?v=${Date.now()}"></script>`
+    const tag = `<script${stamp}>window.__TUBE_NATIVE_PROXY_PATCHES__=${upstream.nativeProxyPatches};</script>`
+        + `<script${stamp} src="${origin}/__tube/userScript.js?v=${Date.now()}"></script>`
         + (DEV_INJECT_PATH ? `<script src="${origin}/__tube/dev.js?v=${Date.now()}"></script>` : '');
 
     // Appended past </html> a browser still runs it; Cobalt's parser drops it.
@@ -150,13 +164,34 @@ const allowOrigin = (req, res) => {
 const create = () => {
     const app = express();
 
+    // When --proxy names the service itself, put the absolute request line back to a path so the
+    // routes below see what they expect.
     app.use((req, _, next) => {
-        if (!journal.wanted()) return next();
+        forward.normaliseSelf(req, PROXY_HOST, ports.PROXY);
+        next();
+    });
 
+    app.use((req, _, next) => {
+        const watching = journal.wanted();
+        const tracing = state.traced < TRACE_LIMIT;
+        if (!watching && !tracing) return next();
+
+        // req.url, not originalUrl: the forward-proxy form has already been put back to a path.
         const path = String(req.url || req.originalUrl);
+        const ours = path.indexOf('/__tube/') === 0;
+        const intercepted = interceptedTls(req);
 
         // Our own /__tube/ requests would drown the page's in the journal.
-        if (path.indexOf('/__tube/') !== 0) journal.service('asked', `${req.method} ${path.slice(0, 150)}`);
+        if (watching && !ours) journal.service('asked', `${req.method} ${path.slice(0, 150)}`);
+
+        if (watching && intercepted) {
+            journal.service('mitmreq', `${req.method} ${path.slice(0, 150)} host=${req.headers.host || '?'}`);
+        }
+
+        if (tracing && intercepted && !ours) {
+            state.traced += 1;
+            postmortem.note('req', `${req.method} ${req.headers.host || '?'}${path.slice(0, 120)}`);
+        }
 
         return next();
     });
@@ -200,9 +235,14 @@ const routeFor = (req) => {
         return raw.indexOf('http') === 0 ? raw : `https://${raw}`;
     };
 
-    const targetOf = (isBypass) => (
-        isBypass ? bypassTarget() : `${YOUTUBE_ORIGIN}${req.url}`
-    );
+    const targetOf = (forwarded, isBypass, intercepted) => {
+        if (forwarded) return forwarded;
+        if (isBypass) return bypassTarget();
+        if (intercepted && req.path.indexOf('/__tube/') === 0) return `${localOrigin()}${req.url}`;
+        if (intercepted && req.headers.host) return `https://${req.headers.host}${req.url}`;
+
+        return `${YOUTUBE_ORIGIN}${req.url}`;
+    };
 
     const hostNamedBy = (target) => {
         try { return URL.parse(target).host || YOUTUBE_HOST; } catch (e) { return YOUTUBE_HOST; }
@@ -213,17 +253,22 @@ const routeFor = (req) => {
         forGoogle && target.indexOf('http://') === 0 ? `https://${target.slice(7)}` : target
     );
 
-    const isBypass = req.path.indexOf('/cors-bypass/') === 0;
+    const forwarded = forward.absoluteTarget(req.url);
+    const isBypass = !forwarded && req.path.indexOf('/cors-bypass/') === 0;
+    const intercepted = interceptedTls(req);
 
-    const target = targetOf(isBypass);
+    const target = targetOf(forwarded, isBypass, intercepted);
     const host = hostNamedBy(target);
     const forGoogle = GOOGLE.test(host.split(':')[0]);
 
+    // asOurselves: whether the answer goes back as youtube.com over our own TLS rather than as the
+    // service on plain HTTP. Cookies and the injection origin both depend on it.
     return {
         url: upgradeScheme(target, forGoogle),
         host,
         forGoogle,
-        isBypass
+        isBypass,
+        asOurselves: intercepted
     };
 };
 
@@ -239,8 +284,10 @@ const headersFor = (req, route) => {
 
     const copied = Object.keys(req.headers)
         .filter((key) => dropped.indexOf(key) === -1)
-        // The page carries renamed cookies, because we served it on plain HTTP.
-        .map((key) => [key, key === 'cookie' ? restoreCookiePrefixes(req.headers[key]) : req.headers[key]]);
+        // The page only carries renamed cookies when we served it as the service on plain HTTP.
+        .map((key) => [key, key === 'cookie' && !route.asOurselves
+            ? restoreCookiePrefixes(req.headers[key])
+            : req.headers[key]]);
 
     return Object.assign({}, Object.fromEntries(copied), { host: route.host }, presented,
         DEV_USER_AGENT ? { 'user-agent': DEV_USER_AGENT } : {},
@@ -263,6 +310,13 @@ const send = (url, req, headers) => {
     };
 
     return fetch(url, options).catch((error) => {
+        // YouTube's header block is larger than Node's HTTP/1 parser will accept and the limit
+        // cannot be raised from in here, so the same request goes again over HTTP/2.
+        if (bigheaders.isHeaderOverflow(error) && !body && url.indexOf('https:') === 0) {
+            postmortem.note('upstream', `header overflow on ${url.slice(0, 80)} — retrying over http2`);
+            return bigheaders.fetchOverHttp2(url, { method: req.method, headers });
+        }
+
         // A streamed body cannot be sent twice.
         if (!isRetriable(error) || body) throw error;
 
@@ -280,10 +334,16 @@ const copyHeaders = (req, res, response, route) => {
         const lower = key.toLowerCase();
 
         if (STRIPPED_HEADERS.indexOf(lower) !== -1) return;
+        // YouTube's own policy names Cobalt's grammar for reaching a private address; a generic
+        // permissive one throws those grants away. It is kept when we answer as youtube.com.
+        if (lower === CSP_HEADER && !route.asOurselves) return;
         if (route.isBypass && lower === 'access-control-allow-origin') return;
 
+        // Over the MITM the page's origin really is https://www.youtube.com, and rewriting cookies
+        // there scopes every one to a domain the page is not on: the client drops the lot and
+        // refetches the page for ever behind a network error.
         if (lower === 'set-cookie' && Array.isArray(raw[key])) {
-            res.setHeader('Set-Cookie', rewriteSetCookie(raw[key]));
+            res.setHeader('Set-Cookie', route.asOurselves ? raw[key] : rewriteSetCookie(raw[key]));
             return;
         }
 
@@ -350,7 +410,14 @@ const attachFallback = (app) => {
                 }
 
                 return response.text().then((text) => {
-                    const injected = rewriteAttestation(rewriteBody(text, req.url), route.url);
+                    const injectionOrigin = route.asOurselves && req.headers.host
+                        ? `https://${req.headers.host}`
+                        : null;
+                    const nonce = route.asOurselves ? nonceOf(response.headers.get(CSP_HEADER)) : null;
+
+                    const injected = rewriteAttestation(
+                        rewriteBody(text, req.url, injectionOrigin, nonce), route.url
+                    );
 
                     const abr = upstream.abrThroughService && route.url.indexOf('/youtubei/v1/player') !== -1;
 

--- a/service/lib/proxy.js
+++ b/service/lib/proxy.js
@@ -47,7 +47,7 @@ const PROXY_HOST = process.env.TUBE_PROXY_HOST || 'localhost';
 const localOrigin = () => `http://${PROXY_HOST}:${ports.PROXY}`;
 const proxyPrefix = () => `${localOrigin()}/cors-bypass/`;
 
-const interceptedTls = (req) => !!(req.socket && (req.socket.__tubeMitm || req.socket.encrypted));
+const overOurTls = (req) => !!(req.socket && req.socket.encrypted);
 
 const flagOverrides = new Map();
 
@@ -58,7 +58,7 @@ const upstream = {
     nativeProxyPatches: true
 };
 
-const nonceOf = (policy) => (/'nonce-([A-Za-z0-9+/_-]+)'/.exec(policy || '') || [])[1] || null;
+const nonceOf = (policy) => (/'nonce-([A-Za-z0-9+/_-]+={0,2})'/.exec(policy || '') || [])[1] || null;
 
 const spoofUserAgent = (text) => {
     const shim = '<script>try{Object.defineProperty(navigator,"userAgent",'
@@ -125,14 +125,12 @@ const rewriteBody = (text, url, injectionOrigin, nonce) => {
         upstream.nativeProxyPatches ? null : overrideInnertubeHost
     ].filter(Boolean).reduce((out, step) => step(out), text);
 
-    // The nonce is quoted from the page's own script-src — without it the injected tags are
-    // refused by the nonce policy YouTube serves a Cobalt client.
     const stamp = nonce ? ` nonce="${nonce}"` : '';
     const origin = injectionOrigin || localOrigin();
 
     const tag = `<script${stamp}>window.__TUBE_NATIVE_PROXY_PATCHES__=${upstream.nativeProxyPatches};</script>`
         + `<script${stamp} src="${origin}/__tube/userScript.js?v=${Date.now()}"></script>`
-        + (DEV_INJECT_PATH ? `<script src="${origin}/__tube/dev.js?v=${Date.now()}"></script>` : '');
+        + (DEV_INJECT_PATH ? `<script${stamp} src="${origin}/__tube/dev.js?v=${Date.now()}"></script>` : '');
 
     // Appended past </html> a browser still runs it; Cobalt's parser drops it.
     return tuned.indexOf('</body>') !== -1 ? tuned.replace('</body>', `${tag}</body>`) : tuned + tag;
@@ -164,8 +162,6 @@ const allowOrigin = (req, res) => {
 const create = () => {
     const app = express();
 
-    // When --proxy names the service itself, put the absolute request line back to a path so the
-    // routes below see what they expect.
     app.use((req, _, next) => {
         forward.normaliseSelf(req, PROXY_HOST, ports.PROXY);
         next();
@@ -179,16 +175,12 @@ const create = () => {
         // req.url, not originalUrl: the forward-proxy form has already been put back to a path.
         const path = String(req.url || req.originalUrl);
         const ours = path.indexOf('/__tube/') === 0;
-        const intercepted = interceptedTls(req);
+        const asked = `${req.method} ${path.slice(0, 150)}`;
 
         // Our own /__tube/ requests would drown the page's in the journal.
-        if (watching && !ours) journal.service('asked', `${req.method} ${path.slice(0, 150)}`);
+        if (watching && !ours) journal.service('asked', overOurTls(req) ? `${asked} host=${req.headers.host || '?'}` : asked);
 
-        if (watching && intercepted) {
-            journal.service('mitmreq', `${req.method} ${path.slice(0, 150)} host=${req.headers.host || '?'}`);
-        }
-
-        if (tracing && intercepted && !ours) {
+        if (tracing && overOurTls(req) && !ours) {
             state.traced += 1;
             postmortem.note('req', `${req.method} ${req.headers.host || '?'}${path.slice(0, 120)}`);
         }
@@ -235,11 +227,10 @@ const routeFor = (req) => {
         return raw.indexOf('http') === 0 ? raw : `https://${raw}`;
     };
 
-    const targetOf = (forwarded, isBypass, intercepted) => {
+    const targetOf = (forwarded, isBypass) => {
         if (forwarded) return forwarded;
         if (isBypass) return bypassTarget();
-        if (intercepted && req.path.indexOf('/__tube/') === 0) return `${localOrigin()}${req.url}`;
-        if (intercepted && req.headers.host) return `https://${req.headers.host}${req.url}`;
+        if (overOurTls(req) && req.headers.host) return `https://${req.headers.host}${req.url}`;
 
         return `${YOUTUBE_ORIGIN}${req.url}`;
     };
@@ -255,20 +246,17 @@ const routeFor = (req) => {
 
     const forwarded = forward.absoluteTarget(req.url);
     const isBypass = !forwarded && req.path.indexOf('/cors-bypass/') === 0;
-    const intercepted = interceptedTls(req);
 
-    const target = targetOf(forwarded, isBypass, intercepted);
+    const target = targetOf(forwarded, isBypass);
     const host = hostNamedBy(target);
     const forGoogle = GOOGLE.test(host.split(':')[0]);
 
-    // asOurselves: whether the answer goes back as youtube.com over our own TLS rather than as the
-    // service on plain HTTP. Cookies and the injection origin both depend on it.
     return {
         url: upgradeScheme(target, forGoogle),
         host,
         forGoogle,
         isBypass,
-        asOurselves: intercepted
+        asTheRealHost: !!forwarded || overOurTls(req)
     };
 };
 
@@ -285,7 +273,7 @@ const headersFor = (req, route) => {
     const copied = Object.keys(req.headers)
         .filter((key) => dropped.indexOf(key) === -1)
         // The page only carries renamed cookies when we served it as the service on plain HTTP.
-        .map((key) => [key, key === 'cookie' && !route.asOurselves
+        .map((key) => [key, key === 'cookie' && !route.asTheRealHost
             ? restoreCookiePrefixes(req.headers[key])
             : req.headers[key]]);
 
@@ -310,8 +298,6 @@ const send = (url, req, headers) => {
     };
 
     return fetch(url, options).catch((error) => {
-        // YouTube's header block is larger than Node's HTTP/1 parser will accept and the limit
-        // cannot be raised from in here, so the same request goes again over HTTP/2.
         if (bigheaders.isHeaderOverflow(error) && !body && url.indexOf('https:') === 0) {
             postmortem.note('upstream', `header overflow on ${url.slice(0, 80)} — retrying over http2`);
             return bigheaders.fetchOverHttp2(url, { method: req.method, headers });
@@ -334,16 +320,13 @@ const copyHeaders = (req, res, response, route) => {
         const lower = key.toLowerCase();
 
         if (STRIPPED_HEADERS.indexOf(lower) !== -1) return;
-        // YouTube's own policy names Cobalt's grammar for reaching a private address; a generic
-        // permissive one throws those grants away. It is kept when we answer as youtube.com.
-        if (lower === CSP_HEADER && !route.asOurselves) return;
+        // Kept for the real host, because YouTube's policy carries Cobalt's private-address grants.
+        if (lower === CSP_HEADER && !route.asTheRealHost) return;
         if (route.isBypass && lower === 'access-control-allow-origin') return;
 
-        // Over the MITM the page's origin really is https://www.youtube.com, and rewriting cookies
-        // there scopes every one to a domain the page is not on: the client drops the lot and
-        // refetches the page for ever behind a network error.
+        // A page on the real host would reject a cookie rewritten to Domain=localhost.
         if (lower === 'set-cookie' && Array.isArray(raw[key])) {
-            res.setHeader('Set-Cookie', route.asOurselves ? raw[key] : rewriteSetCookie(raw[key]));
+            res.setHeader('Set-Cookie', route.asTheRealHost ? raw[key] : rewriteSetCookie(raw[key]));
             return;
         }
 
@@ -410,10 +393,10 @@ const attachFallback = (app) => {
                 }
 
                 return response.text().then((text) => {
-                    const injectionOrigin = route.asOurselves && req.headers.host
+                    const injectionOrigin = route.asTheRealHost && req.headers.host
                         ? `https://${req.headers.host}`
                         : null;
-                    const nonce = route.asOurselves ? nonceOf(response.headers.get(CSP_HEADER)) : null;
+                    const nonce = route.asTheRealHost ? nonceOf(response.headers.get(CSP_HEADER)) : null;
 
                     const injected = rewriteAttestation(
                         rewriteBody(text, req.url, injectionOrigin, nonce), route.url

--- a/service/lib/x509.js
+++ b/service/lib/x509.js
@@ -1,0 +1,229 @@
+'use strict';
+
+// A certificate issuer, small enough to carry. The CA that signs our interception certificate is
+// made on the television: one CA baked into a public release would put its private key in every
+// download. Node's crypto only parses certificates, so the DER is written by hand.
+
+const crypto = require('crypto');
+
+// -- DER -----------------------------------------------------------------------------------------
+
+const length = (n) => {
+    if (n < 0x80) return Buffer.from([n]);
+
+    const base256 = (value) => (value > 0 ? base256(Math.floor(value / 256)).concat(value % 256) : []);
+
+    const bytes = base256(n);
+
+    return Buffer.concat([Buffer.from([0x80 | bytes.length]), Buffer.from(bytes)]);
+};
+
+const tagged = (tag, body) => Buffer.concat([Buffer.from([tag]), length(body.length), body]);
+
+const sequence = (...parts) => tagged(0x30, Buffer.concat(parts));
+const set = (...parts) => tagged(0x31, Buffer.concat(parts));
+const utf8 = (text) => tagged(0x0c, Buffer.from(text, 'utf8'));
+const octets = (body) => tagged(0x04, body);
+const boolean = (yes) => tagged(0x01, Buffer.from([yes ? 0xff : 0x00]));
+const explicit = (n, body) => tagged(0xa0 | n, body);
+const implicit = (n, body) => tagged(0x80 | n, body);
+const nul = Buffer.from([0x05, 0x00]);
+
+// A DER INTEGER is signed, so a leading bit set needs a zero byte in front of it.
+const integer = (value) => {
+    const withoutLeadingZeroes = (bytes) => (
+        bytes.length > 1 && bytes[0] === 0 && !(bytes[1] & 0x80)
+            ? withoutLeadingZeroes(bytes.slice(1))
+            : bytes
+    );
+
+    const trimmed = withoutLeadingZeroes(Buffer.isBuffer(value) ? value : Buffer.from([value]));
+
+    return tagged(0x02, trimmed[0] & 0x80 ? Buffer.concat([Buffer.from([0]), trimmed]) : trimmed);
+};
+
+// Everything wrapped here is a whole number of octets, so the unused-bits byte is always zero.
+const bitString = (body) => tagged(0x03, Buffer.concat([Buffer.from([0]), body]));
+
+const oid = (dotted) => {
+    const parts = dotted.split('.').map(Number);
+
+    const carry = (rest) => (rest > 0 ? carry(Math.floor(rest / 128)).concat((rest & 0x7f) | 0x80) : []);
+
+    const varint = (part) => carry(Math.floor(part / 128)).concat(part & 0x7f);
+
+    const encoded = parts.slice(2).reduce(
+        (bytes, part) => bytes.concat(varint(part)),
+        [parts[0] * 40 + parts[1]]
+    );
+
+    return tagged(0x06, Buffer.from(encoded));
+};
+
+const OID = {
+    commonName: '2.5.4.3',
+    rsaEncryption: '1.2.840.113549.1.1.1',
+    sha256WithRSA: '1.2.840.113549.1.1.11',
+    basicConstraints: '2.5.29.19',
+    keyUsage: '2.5.29.15',
+    subjectAltName: '2.5.29.17',
+    extKeyUsage: '2.5.29.37',
+    serverAuth: '1.3.6.1.5.5.7.3.1',
+    subjectKeyIdentifier: '2.5.29.14',
+    authorityKeyIdentifier: '2.5.29.35'
+};
+
+// UTCTime, which is what every certificate before 2050 uses.
+const utcTime = (date) => {
+    const pad = (n) => String(n).padStart(2, '0');
+
+    return tagged(0x17, Buffer.from(
+        pad(date.getUTCFullYear() % 100) + pad(date.getUTCMonth() + 1) + pad(date.getUTCDate())
+        + pad(date.getUTCHours()) + pad(date.getUTCMinutes()) + pad(date.getUTCSeconds()) + 'Z',
+        'ascii'
+    ));
+};
+
+// -- names ---------------------------------------------------------------------------------------
+
+const name = (commonName) => sequence(set(sequence(oid(OID.commonName), utf8(commonName))));
+
+// OpenSSL hashes the canonical encoding: values become UTF8String, ASCII folds to lower case, runs
+// of whitespace collapse, and there is no outer SEQUENCE — i2d_name_canon concatenates the RDN
+// sets and stops. Getting this wrong names the file something the container never looks for, and
+// the handshake simply fails as though the CA were absent. Pinned in service/test/x509.js.
+const canonical = (commonName) => set(sequence(
+    oid(OID.commonName),
+    utf8(commonName.replace(/\s+/g, ' ').trim().toLowerCase())
+));
+
+// The first four bytes of the digest, read little-endian: SHA-1 over the canonical encoding for
+// -subject_hash, MD5 over the raw DER for -subject_hash_old.
+const hashName = (digest, encoded) => {
+    const md = crypto.createHash(digest).update(encoded).digest();
+
+    return ((md[0] | (md[1] << 8) | (md[2] << 16) | (md[3] << 24)) >>> 0).toString(16).padStart(8, '0');
+};
+
+const subjectHashes = (commonName) => ({
+    hash: hashName('sha1', canonical(commonName)),
+    hashOld: hashName('md5', name(commonName))
+});
+
+// -- certificates --------------------------------------------------------------------------------
+
+const algorithm = sequence(oid(OID.sha256WithRSA), nul);
+
+// Built rather than exported, so the BIT STRING contents are in hand for the key identifier.
+const publicKeyInfo = (key) => {
+    const pkcs1 = crypto.createPublicKey(key).export({ type: 'pkcs1', format: 'der' });
+
+    return {
+        spki: sequence(sequence(oid(OID.rsaEncryption), nul), bitString(pkcs1)),
+        identifier: crypto.createHash('sha1').update(pkcs1).digest()
+    };
+};
+
+const extension = (id, critical, body) => (critical
+    ? sequence(oid(id), boolean(true), octets(body))
+    : sequence(oid(id), octets(body)));
+
+// Numbered from the most significant bit of the first byte, so the DER carries the count of unused
+// trailing bits rather than a zero.
+const keyUsage = (bits) => {
+    const highest = Math.max(...bits);
+
+    const byteAt = (index) => bits
+        .filter((bit) => Math.floor(bit / 8) === index)
+        .reduce((byte, bit) => byte | (0x80 >> (bit % 8)), 0);
+
+    const bytes = Buffer.from(Array.from({ length: Math.floor(highest / 8) + 1 }, (_, i) => byteAt(i)));
+
+    return tagged(0x03, Buffer.concat([Buffer.from([7 - (highest % 8)]), bytes]));
+};
+
+const certificate = ({ subject, issuer, subjectKey, issuerKey, days, extensions }) => {
+    const from = new Date();
+    const to = new Date(from.getTime() + days * 24 * 60 * 60 * 1000);
+
+    const tbs = sequence(
+        explicit(0, integer(Buffer.from([2]))),            // v3
+        integer(crypto.randomBytes(16)),
+        algorithm,
+        name(issuer),
+        sequence(utcTime(from), utcTime(to)),
+        name(subject),
+        subjectKey.spki,
+        explicit(3, sequence(...extensions))
+    );
+
+    const der = sequence(tbs, algorithm, bitString(crypto.createSign('RSA-SHA256').update(tbs).sign(issuerKey)));
+
+    return {
+        der,
+        pem: `-----BEGIN CERTIFICATE-----\n${
+            der.toString('base64').replace(/(.{64})/g, '$1\n').replace(/\n$/, '')
+        }\n-----END CERTIFICATE-----\n`
+    };
+};
+
+const generateKey = (done) => crypto.generateKeyPair('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' }
+}, (error, publicKey, privateKey) => done(error, error ? null : { publicKey, privateKey }));
+
+// Trusted by nothing but the copy of Cobalt's content directory we stage beside it.
+const createCa = (commonName, done) => generateKey((error, key) => {
+    if (error) return done(error);
+
+    const info = publicKeyInfo(key.publicKey);
+
+    const cert = certificate({
+        subject: commonName,
+        issuer: commonName,
+        subjectKey: info,
+        issuerKey: key.privateKey,
+        days: 3650,
+        extensions: [
+            extension(OID.basicConstraints, true, sequence(boolean(true))),
+            extension(OID.keyUsage, true, keyUsage([5, 6])),   // keyCertSign, cRLSign
+            extension(OID.subjectKeyIdentifier, false, octets(info.identifier))
+        ]
+    });
+
+    return done(null, { key: key.privateKey, cert: cert.pem, identifier: info.identifier, commonName });
+});
+
+// 397 days, and it must stay under 398: Chromium refuses a longer-lived leaf, and Cobalt has no
+// notion of a locally added root that would be exempt — everything in the staged ssl/certs is its
+// built-in store.
+const createLeaf = (ca, commonName, altNames, done) => generateKey((error, key) => {
+    if (error) return done(error);
+
+    const info = publicKeyInfo(key.publicKey);
+
+    const cert = certificate({
+        subject: commonName,
+        issuer: ca.commonName,
+        subjectKey: info,
+        issuerKey: ca.key,
+        days: 397,
+        extensions: [
+            extension(OID.basicConstraints, true, sequence()),
+            extension(OID.keyUsage, true, keyUsage([0, 2])),   // digitalSignature, keyEncipherment
+            extension(OID.extKeyUsage, false, sequence(oid(OID.serverAuth))),
+            extension(OID.subjectAltName, false,
+                sequence(...altNames.map((host) => implicit(2, Buffer.from(host, 'ascii'))))),
+            extension(OID.subjectKeyIdentifier, false, octets(info.identifier)),
+            extension(OID.authorityKeyIdentifier, false, sequence(implicit(0, ca.identifier)))
+        ]
+    });
+
+    return done(null, { key: key.privateKey, cert: cert.pem, chain: cert.pem + ca.cert });
+});
+
+// Node 4 has no key generation at all, and the container route does not exist on a set that old.
+const available = () => typeof crypto.generateKeyPair === 'function';
+
+module.exports = { available, createCa, createLeaf, subjectHashes };

--- a/service/lib/x509.js
+++ b/service/lib/x509.js
@@ -1,8 +1,6 @@
 'use strict';
 
-// A certificate issuer, small enough to carry. The CA that signs our interception certificate is
-// made on the television: one CA baked into a public release would put its private key in every
-// download. Node's crypto only parses certificates, so the DER is written by hand.
+// Issues a CA and leaf certificates by writing the DER directly, since Node's crypto cannot.
 
 const crypto = require('crypto');
 
@@ -73,6 +71,13 @@ const OID = {
     authorityKeyIdentifier: '2.5.29.35'
 };
 
+const KEY_USAGE = { digitalSignature: 0, keyEncipherment: 2, keyCertSign: 5, cRLSign: 6 };
+
+const CA_DAYS = 3650;
+
+// Chromium refuses a leaf valid for more than 398 days.
+const LEAF_DAYS = 397;
+
 // UTCTime, which is what every certificate before 2050 uses.
 const utcTime = (date) => {
     const pad = (n) => String(n).padStart(2, '0');
@@ -88,10 +93,8 @@ const utcTime = (date) => {
 
 const name = (commonName) => sequence(set(sequence(oid(OID.commonName), utf8(commonName))));
 
-// OpenSSL hashes the canonical encoding: values become UTF8String, ASCII folds to lower case, runs
-// of whitespace collapse, and there is no outer SEQUENCE — i2d_name_canon concatenates the RDN
-// sets and stops. Getting this wrong names the file something the container never looks for, and
-// the handshake simply fails as though the CA were absent. Pinned in service/test/x509.js.
+// OpenSSL hashes the canonical name: UTF8String values, ASCII lower-cased, whitespace collapsed,
+// RDN sets concatenated without an outer SEQUENCE.
 const canonical = (commonName) => set(sequence(
     oid(OID.commonName),
     utf8(commonName.replace(/\s+/g, ' ').trim().toLowerCase())
@@ -173,7 +176,6 @@ const generateKey = (done) => crypto.generateKeyPair('rsa', {
     publicKeyEncoding: { type: 'spki', format: 'pem' }
 }, (error, publicKey, privateKey) => done(error, error ? null : { publicKey, privateKey }));
 
-// Trusted by nothing but the copy of Cobalt's content directory we stage beside it.
 const createCa = (commonName, done) => generateKey((error, key) => {
     if (error) return done(error);
 
@@ -184,10 +186,10 @@ const createCa = (commonName, done) => generateKey((error, key) => {
         issuer: commonName,
         subjectKey: info,
         issuerKey: key.privateKey,
-        days: 3650,
+        days: CA_DAYS,
         extensions: [
             extension(OID.basicConstraints, true, sequence(boolean(true))),
-            extension(OID.keyUsage, true, keyUsage([5, 6])),   // keyCertSign, cRLSign
+            extension(OID.keyUsage, true, keyUsage([KEY_USAGE.keyCertSign, KEY_USAGE.cRLSign])),
             extension(OID.subjectKeyIdentifier, false, octets(info.identifier))
         ]
     });
@@ -195,9 +197,6 @@ const createCa = (commonName, done) => generateKey((error, key) => {
     return done(null, { key: key.privateKey, cert: cert.pem, identifier: info.identifier, commonName });
 });
 
-// 397 days, and it must stay under 398: Chromium refuses a longer-lived leaf, and Cobalt has no
-// notion of a locally added root that would be exempt — everything in the staged ssl/certs is its
-// built-in store.
 const createLeaf = (ca, commonName, altNames, done) => generateKey((error, key) => {
     if (error) return done(error);
 
@@ -208,10 +207,10 @@ const createLeaf = (ca, commonName, altNames, done) => generateKey((error, key) 
         issuer: ca.commonName,
         subjectKey: info,
         issuerKey: ca.key,
-        days: 397,
+        days: LEAF_DAYS,
         extensions: [
             extension(OID.basicConstraints, true, sequence()),
-            extension(OID.keyUsage, true, keyUsage([0, 2])),   // digitalSignature, keyEncipherment
+            extension(OID.keyUsage, true, keyUsage([KEY_USAGE.digitalSignature, KEY_USAGE.keyEncipherment])),
             extension(OID.extKeyUsage, false, sequence(oid(OID.serverAuth))),
             extension(OID.subjectAltName, false,
                 sequence(...altNames.map((host) => implicit(2, Buffer.from(host, 'ascii'))))),

--- a/service/package.json
+++ b/service/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "build": "node build/build.js",
-    "test": "node test/injection.js && node test/routing.js && node test/proxying.js && node test/x509.js && node test/loader.js && node test/update-flow.js && node test/update-scheduling.js",
+    "test": "node test/injection.js && node test/routing.js && node test/proxying.js && node test/x509.js && node test/forward.js && node test/bigheaders.js && node test/loader.js && node test/update-flow.js && node test/update-scheduling.js",
     "check:floor": "node ../tools/check-output.js dist/index.js node12"
   },
   "dependencies": {

--- a/service/package.json
+++ b/service/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "build": "node build/build.js",
-    "test": "node test/injection.js && node test/routing.js && node test/proxying.js && node test/loader.js && node test/update-flow.js && node test/update-scheduling.js",
+    "test": "node test/injection.js && node test/routing.js && node test/proxying.js && node test/x509.js && node test/loader.js && node test/update-flow.js && node test/update-scheduling.js",
     "check:floor": "node ../tools/check-output.js dist/index.js node12"
   },
   "dependencies": {

--- a/service/test/bigheaders.js
+++ b/service/test/bigheaders.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const http2 = require('http2');
+const zlib = require('zlib');
+
+const bigheaders = require('../lib/bigheaders.js');
+const x509 = require('../lib/x509.js');
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+let failures = 0;
+
+function check(label, ok, detail) {
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : `  ${detail}`}`);
+    if (!ok) failures += 1;
+}
+
+const finish = () => {
+    console.log(failures ? `\n${failures} failed.` : '\nall checks passed');
+    process.exit(failures ? 1 : 0);
+};
+
+check('an overflow is recognised by its code', bigheaders.isHeaderOverflow({ code: 'HPE_HEADER_OVERFLOW' }));
+check('an overflow is recognised by its message', bigheaders.isHeaderOverflow(new Error('Parse Error: Header overflow')));
+check('another failure is not an overflow', !bigheaders.isHeaderOverflow(new Error('socket hang up')));
+check('no error is not an overflow', !bigheaders.isHeaderOverflow(null));
+
+const PAGE = `<html><body>${'tube '.repeat(2000)}</body></html>`;
+const POLICY = `script-src ${"'nonce-abc' ".repeat(2000)}`.trim();
+const ENCODE = { gzip: zlib.gzipSync, deflate: zlib.deflateSync };
+
+const fetched = (origin, encoding) => bigheaders.fetchOverHttp2(`${origin}/${encoding}`, {
+    method: 'GET',
+    headers: { connection: 'keep-alive', host: 'www.youtube.com', 'accept-encoding': 'gzip, deflate' }
+});
+
+const serve = (leaf) => {
+    const server = http2.createSecureServer({ key: leaf.key, cert: leaf.chain });
+
+    server.on('stream', (stream, headers) => {
+        const encoding = headers[':path'].slice(1);
+        const body = ENCODE[encoding](PAGE);
+
+        stream.respond({
+            ':status': 200,
+            'content-type': 'text/html',
+            'content-encoding': encoding,
+            'content-length': String(body.length),
+            'content-security-policy': POLICY
+        });
+        stream.end(body);
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+        const origin = `https://127.0.0.1:${server.address().port}`;
+
+        fetched(origin, 'gzip')
+            .then((response) => {
+                check('the status comes through', response.status === 200, response.status);
+                check('a header past HTTP/1\'s limit comes through',
+                    response.headers.get('content-security-policy') === POLICY);
+                check('no pseudo-header is handed on',
+                    Object.keys(response.headers.raw()).every((name) => name[0] !== ':'));
+                check('the body is no longer said to be encoded', response.headers.get('content-encoding') === null);
+                check('nor to have its encoded length', response.headers.get('content-length') === null);
+                return response.text();
+            })
+            .then((text) => check('a gzipped body is decoded', text === PAGE, text.slice(0, 60)))
+            .then(() => fetched(origin, 'deflate'))
+            .then((response) => response.text())
+            .then((text) => check('a deflated body is decoded', text === PAGE, text.slice(0, 60)))
+            .catch((error) => check('the fetch completes', false, error.message))
+            .then(finish);
+    });
+};
+
+x509.createCa('Tube Test CA', (caError, ca) => {
+    if (caError) {
+        check('the server\'s CA is issued', false, caError.message);
+        return finish();
+    }
+
+    return x509.createLeaf(ca, 'localhost', ['localhost'], (leafError, leaf) => {
+        if (leafError) {
+            check('the server\'s certificate is issued', false, leafError.message);
+            return finish();
+        }
+
+        return serve(leaf);
+    });
+});

--- a/service/test/forward.js
+++ b/service/test/forward.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const forward = require('../lib/forward.js');
+
+let failures = 0;
+
+function check(label, ok, detail) {
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : `  ${detail}`}`);
+    if (!ok) failures += 1;
+}
+
+const normalised = (url) => {
+    const req = { url };
+    forward.normaliseSelf(req, 'tv.example', 8099);
+    return req.url;
+};
+
+[
+    ['our host and port', 'http://tv.example:8099/tv?x=1', '/tv?x=1'],
+    ['our host without its port', 'http://tv.example/tv', '/tv'],
+    ['localhost', 'http://localhost:8099/__tube/state', '/__tube/state'],
+    ['loopback without a port', 'http://127.0.0.1/tv', '/tv'],
+    ['our host with no path', 'http://tv.example:8099', '/']
+].forEach(([label, url, path]) => {
+    check(`${label} becomes a path`, normalised(url) === path, normalised(url));
+});
+
+[
+    ['another host', 'http://www.youtube.com/tv'],
+    ['another port on our host', 'http://tv.example:9000/tv'],
+    ['a path', '/tv']
+].forEach(([label, url]) => {
+    check(`${label} is left as it was`, normalised(url) === url, normalised(url));
+});
+
+check('an absolute URL is a forward target',
+    forward.absoluteTarget('https://www.youtube.com/tv') === 'https://www.youtube.com/tv');
+check('a path is not a forward target', forward.absoluteTarget('/tv') === null);
+
+console.log(failures ? `\n${failures} failed.` : '\nall checks passed');
+process.exit(failures ? 1 : 0);

--- a/service/test/injection.js
+++ b/service/test/injection.js
@@ -38,6 +38,15 @@ check('/tv is injected into exactly once', injected.split('__tube/userScript.js'
 
 check('/tv_config is not injected into', rewriteBody('<html></html>', '/tv_config').indexOf('__tube') === -1);
 
+check('/tv without a nonce stamps none', injected.indexOf('nonce=') === -1, injected);
+
+const overTls = rewriteBody('<html><body></body></html>', '/tv', 'https://www.youtube.com', 'n0nce+/=');
+const overTlsTags = overTls.match(/<script[^>]*>/g) || [];
+check('over our TLS the script comes from the page\'s own origin',
+    overTls.indexOf('https://www.youtube.com/__tube/userScript.js') !== -1 && overTls.indexOf(ORIGIN) === -1, overTls);
+check('over our TLS every injected tag carries the page\'s nonce',
+    overTlsTags.length > 0 && overTlsTags.every((tag) => tag.indexOf(' nonce="n0nce+/="') !== -1), overTlsTags.join(' '));
+
 const player = rewriteAttestation(
     'var x="https://jnn-pa.googleapis.com/$rpc/google.internal.waa.v1.Waa/GenerateIT";',
     'https://www.youtube.com/s/player/abc/tv-player-es6-tcl.js'

--- a/service/test/x509.js
+++ b/service/test/x509.js
@@ -1,15 +1,14 @@
 'use strict';
 
-// The certificate issuer, checked against the tool that defines the format. Every one of these
-// failures is silent on a television — a certificate the container will not accept, or a file
-// named something it never looks for — so they are worth catching here.
+// Checks the issuer's certificates and subject hashes against openssl.
 
 const { execFileSync } = require('child_process');
-const { mkdtempSync, writeFileSync } = require('fs');
+const { mkdtempSync, rmSync, writeFileSync } = require('fs');
 const { tmpdir } = require('os');
 const { join } = require('path');
 
 const x509 = require('../lib/x509.js');
+const { INTERCEPTED } = require('../lib/mitm.js');
 
 let failures = 0;
 
@@ -21,33 +20,33 @@ function check(label, ok, detail) {
 const dir = mkdtempSync(join(tmpdir(), 'tube-x509-'));
 const openssl = (args) => execFileSync('openssl', args, { encoding: 'utf8' });
 
-// The pair of names the certificate that first worked inside the container was filed under, taken
-// off the television. It costs nothing to check and it pins the hash to a value observed in the
-// wild rather than only to whatever openssl on this machine happens to say.
+const finish = (code) => {
+    rmSync(dir, { recursive: true, force: true });
+    process.exit(code);
+};
+
 const known = x509.subjectHashes('Tube Cobalt Experiment CA');
-check('the hashes reproduce a name that worked on the set',
+check('subject hashes of a known name',
     known.hash === '24de7fb5' && known.hashOld === '147bf03f', JSON.stringify(known));
 
 const CA_NAME = 'Tube Local CA On This Set';
-const HOSTS = ['youtube.com', '*.youtube.com', 'googlevideo.com', '*.googlevideo.com'];
+const HOSTS = INTERCEPTED.flatMap((domain) => [domain, `*.${domain}`]);
 
 x509.createCa(CA_NAME, (error, ca) => {
     if (error) {
         check('the CA is issued', false, error.message);
-        return process.exit(1);
+        return finish(1);
     }
 
     const caPath = join(dir, 'ca.crt');
     writeFileSync(caPath, ca.cert);
 
-    // A certificate openssl cannot parse fails here rather than on the set.
     const text = openssl(['x509', '-in', caPath, '-noout', '-text']);
     check('the CA parses', text.indexOf('Signature Algorithm: sha256WithRSAEncryption') !== -1);
     check('the CA is a CA', /CA:TRUE/.test(text), text.slice(0, 200));
     check('the CA can sign certificates', /Certificate Sign/.test(text));
     check('the CA carries a subject key identifier', /Subject Key Identifier/.test(text));
 
-    // The whole point of the exercise: the file name the container looks for.
     const ours = x509.subjectHashes(CA_NAME);
     const theirs = openssl(['x509', '-in', caPath, '-noout', '-subject_hash']).trim();
     const theirsOld = openssl(['x509', '-in', caPath, '-noout', '-subject_hash_old']).trim();
@@ -58,7 +57,7 @@ x509.createCa(CA_NAME, (error, ca) => {
     x509.createLeaf(ca, 'www.youtube.com', HOSTS, (leafError, leaf) => {
         if (leafError) {
             check('the leaf is issued', false, leafError.message);
-            return process.exit(1);
+            return finish(1);
         }
 
         const leafPath = join(dir, 'leaf.crt');
@@ -73,7 +72,6 @@ x509.createCa(CA_NAME, (error, ca) => {
             check(`the leaf names ${host}`, leafText.indexOf(`DNS:${host}`) !== -1);
         });
 
-        // Over 398 days and Chromium refuses it outright, which is what the whole round cost.
         const dates = openssl(['x509', '-in', leafPath, '-noout', '-dates']);
         const from = new Date(/notBefore=(.*)/.exec(dates)[1]);
         const to = new Date(/notAfter=(.*)/.exec(dates)[1]);
@@ -89,6 +87,6 @@ x509.createCa(CA_NAME, (error, ca) => {
         check('the chain carries both certificates', leaf.chain.split('BEGIN CERTIFICATE').length === 3);
 
         console.log(failures ? `\n${failures} failed.` : '\nall checks passed');
-        process.exit(failures ? 1 : 0);
+        finish(failures ? 1 : 0);
     });
 });

--- a/service/test/x509.js
+++ b/service/test/x509.js
@@ -1,0 +1,94 @@
+'use strict';
+
+// The certificate issuer, checked against the tool that defines the format. Every one of these
+// failures is silent on a television — a certificate the container will not accept, or a file
+// named something it never looks for — so they are worth catching here.
+
+const { execFileSync } = require('child_process');
+const { mkdtempSync, writeFileSync } = require('fs');
+const { tmpdir } = require('os');
+const { join } = require('path');
+
+const x509 = require('../lib/x509.js');
+
+let failures = 0;
+
+function check(label, ok, detail) {
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : `  ${detail}`}`);
+    if (!ok) failures += 1;
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'tube-x509-'));
+const openssl = (args) => execFileSync('openssl', args, { encoding: 'utf8' });
+
+// The pair of names the certificate that first worked inside the container was filed under, taken
+// off the television. It costs nothing to check and it pins the hash to a value observed in the
+// wild rather than only to whatever openssl on this machine happens to say.
+const known = x509.subjectHashes('Tube Cobalt Experiment CA');
+check('the hashes reproduce a name that worked on the set',
+    known.hash === '24de7fb5' && known.hashOld === '147bf03f', JSON.stringify(known));
+
+const CA_NAME = 'Tube Local CA On This Set';
+const HOSTS = ['youtube.com', '*.youtube.com', 'googlevideo.com', '*.googlevideo.com'];
+
+x509.createCa(CA_NAME, (error, ca) => {
+    if (error) {
+        check('the CA is issued', false, error.message);
+        return process.exit(1);
+    }
+
+    const caPath = join(dir, 'ca.crt');
+    writeFileSync(caPath, ca.cert);
+
+    // A certificate openssl cannot parse fails here rather than on the set.
+    const text = openssl(['x509', '-in', caPath, '-noout', '-text']);
+    check('the CA parses', text.indexOf('Signature Algorithm: sha256WithRSAEncryption') !== -1);
+    check('the CA is a CA', /CA:TRUE/.test(text), text.slice(0, 200));
+    check('the CA can sign certificates', /Certificate Sign/.test(text));
+    check('the CA carries a subject key identifier', /Subject Key Identifier/.test(text));
+
+    // The whole point of the exercise: the file name the container looks for.
+    const ours = x509.subjectHashes(CA_NAME);
+    const theirs = openssl(['x509', '-in', caPath, '-noout', '-subject_hash']).trim();
+    const theirsOld = openssl(['x509', '-in', caPath, '-noout', '-subject_hash_old']).trim();
+
+    check('subject_hash matches openssl', ours.hash === theirs, `${ours.hash} vs ${theirs}`);
+    check('subject_hash_old matches openssl', ours.hashOld === theirsOld, `${ours.hashOld} vs ${theirsOld}`);
+
+    x509.createLeaf(ca, 'www.youtube.com', HOSTS, (leafError, leaf) => {
+        if (leafError) {
+            check('the leaf is issued', false, leafError.message);
+            return process.exit(1);
+        }
+
+        const leafPath = join(dir, 'leaf.crt');
+        writeFileSync(leafPath, leaf.cert);
+        const leafText = openssl(['x509', '-in', leafPath, '-noout', '-text']);
+
+        check('the leaf chains to the CA', openssl(['verify', '-CAfile', caPath, leafPath]).indexOf('OK') !== -1);
+        check('the leaf is not a CA', /CA:FALSE/.test(leafText) || !/CA:TRUE/.test(leafText));
+        check('the leaf is for server authentication', /TLS Web Server Authentication/.test(leafText));
+
+        HOSTS.forEach((host) => {
+            check(`the leaf names ${host}`, leafText.indexOf(`DNS:${host}`) !== -1);
+        });
+
+        // Over 398 days and Chromium refuses it outright, which is what the whole round cost.
+        const dates = openssl(['x509', '-in', leafPath, '-noout', '-dates']);
+        const from = new Date(/notBefore=(.*)/.exec(dates)[1]);
+        const to = new Date(/notAfter=(.*)/.exec(dates)[1]);
+        const days = Math.round((to - from) / 86400000);
+        check('the leaf lives inside the 398-day limit', days > 0 && days < 398, `${days} days`);
+
+        // The private key has to match, or the handshake dies with no useful message.
+        writeFileSync(join(dir, 'leaf.key'), leaf.key);
+        const keyModulus = openssl(['rsa', '-in', join(dir, 'leaf.key'), '-noout', '-modulus']);
+        const certModulus = openssl(['x509', '-in', leafPath, '-noout', '-modulus']);
+        check('the leaf key matches the leaf', keyModulus === certModulus);
+
+        check('the chain carries both certificates', leaf.chain.split('BEGIN CERTIFICATE').length === 3);
+
+        console.log(failures ? `\n${failures} failed.` : '\nall checks passed');
+        process.exit(failures ? 1 : 0);
+    });
+});


### PR DESCRIPTION
Serving youtube.com from `http://<set>:8099` costs more than it looks. Cookies
have to be renamed out of their `__Secure-` prefix and rescoped to our host,
YouTube's own Content-Security-Policy has to be thrown away because it names
origins the page is no longer on, and every proof-of-origin token is minted at
an origin the server did not expect. Each of those is a small lie the page then
has to be talked out of noticing.

Standing in front of the connection instead removes all three at once. A client
pointed at this proxy sends CONNECT for TLS; for the hosts we care about the
handshake is answered here with our own certificate and the decrypted stream is
fed into the same Express app, so the page's origin really is
`https://www.youtube.com` and nothing about it has to be rewritten. Everything
else is a blind tunnel — googlevideo included, deliberately: standing in front
of media buys nothing but latency.

The authority is made on the television. One CA baked into a public release
would put its private key in every download, so `x509.js` writes the DER by
hand — Node's crypto only parses certificates — and issues a CA and a leaf on
first run. Until that finishes, and whenever a `disabled` file sits beside the
keys, every host is tunnelled untouched, which is a working television showing
stock YouTube.

`bigheaders.js` comes with it because it has to: YouTube's answer to a Cobalt
client carries 16.3KB of headers, almost all of it one CSP, and Node caps the
block at 8KB on node 12 and 16KB from node 14 with no way to raise it from
inside the process. HTTP/2 carries headers in HPACK, where the limit is an order
of magnitude higher, so an overflowing request goes again over h2.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>