### PR TITLE
Run the app inside Samsung's Cobalt container

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -12,23 +12,14 @@
     <!-- use.game.mode must stay absent: it makes the renderer count frames, but the video
          element then sits at networkState 0 with no error and every video falls back to
          the default player. -->
-    <!-- Must stay true. Setting it false was tried against the reopen-after-force-close failure and
-         made it worse: the app then would not start even the first time. -->
+    <!-- Must stay true: false stops the app from starting at all. -->
     <tizen:metadata key="http://samsung.com/tv/metadata/prelaunch.support" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/floating.navigation" value="false"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/use.uwe" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/no_use_process_pool" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/html5.4k.support" value="true"/>
 
-    <!-- Claims the Cobalt container slot, the stack that plays 2160p60 VP9 HDR properly.
-         nativeID cannot be dropped: the slot carries read.metadata.from.hybrid.webapp, so it takes
-         its switches from the webapp nativeID pairs it to, and without it the container arrives
-         with none of them. That also means this package never runs its own content.
-         proxy names 127.0.0.2 because one package cannot reach another's 127.0.0.1 on this
-         platform (EHOSTUNREACH), while any other loopback address connects — so this is a fixed
-         string meaning "this television" on every television, with no DNS and nothing per-set.
-         content must be the Evergreen content directory itself, never the tree above it; the
-         service stages that copy, and the authority inside it, on first run. -->
+    <!-- proxy names 127.0.0.2 because the container, another package, cannot reach this one's 127.0.0.1. -->
     <tizen:metadata key="http://samsung.com/tv/metadata/pkgid" value="com.samsung.tv.cobalt"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/nativeID" value="com.samsung.tv.cobalt-yt"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/native.userdata" value="--base_url=https://www.youtube.com/tv --proxy=http://127.0.0.2:8099 --content=/home/owner/share/tube/cobalt-content --dial_name=Tube --use_eden"/>
@@ -56,11 +47,8 @@
     <tizen:profile name="tv-samsung"/>
 
 
-    <!-- auto-restart and on-boot are what bring the service back when the set wakes from standby —
-         observed directly: a new pid appears in service.log on resume, and without them nothing
-         would start it, because a package carrying nativeID never runs its own content. They are
-         documented as restricted to platform and partner signed packages, and this set holds a
-         partner pair, so whether they work on an ordinary public one is still an open question. -->
+    <!-- Without auto-restart and on-boot nothing restarts the service after standby, because a
+         package carrying nativeID never runs its own content. -->
     <tizen:service id="9Ur5IzDKqV.TubeService" auto-restart="true" on-boot="true">
         <tizen:content src="service/dist/index.js"/>
         <tizen:name>TubeService</tizen:name>

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns:tizen="http://tizen.org/ns/widgets" xmlns="http://www.w3.org/ns/widgets" id="https://tube.local" version="0.3.1" viewmodes="maximized">
     <access origin="*" subdomains="true"></access>
     <tizen:allow-navigation href="*"/>
-    <tizen:application id="tUb3Xq7Lm9.Tube" package="tUb3Xq7Lm9" required_version="5.0"/>
+    <tizen:application id="9Ur5IzDKqV.TizenYouTube" package="9Ur5IzDKqV" required_version="5.0"/>
     <author>tube</author>
     <content src="ui/dist/index.html"/>
     <feature name="http://tizen.org/feature/screen.size.all"/>
@@ -12,18 +12,33 @@
     <!-- use.game.mode must stay absent: it makes the renderer count frames, but the video
          element then sits at networkState 0 with no error and every video falls back to
          the default player. -->
+    <!-- Must stay true. Setting it false was tried against the reopen-after-force-close failure and
+         made it worse: the app then would not start even the first time. -->
     <tizen:metadata key="http://samsung.com/tv/metadata/prelaunch.support" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/floating.navigation" value="false"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/use.uwe" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/no_use_process_pool" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/html5.4k.support" value="true"/>
 
+    <!-- Claims the Cobalt container slot, the stack that plays 2160p60 VP9 HDR properly.
+         nativeID cannot be dropped: the slot carries read.metadata.from.hybrid.webapp, so it takes
+         its switches from the webapp nativeID pairs it to, and without it the container arrives
+         with none of them. That also means this package never runs its own content.
+         proxy names 127.0.0.2 because one package cannot reach another's 127.0.0.1 on this
+         platform (EHOSTUNREACH), while any other loopback address connects — so this is a fixed
+         string meaning "this television" on every television, with no DNS and nothing per-set.
+         content must be the Evergreen content directory itself, never the tree above it; the
+         service stages that copy, and the authority inside it, on first run. -->
+    <tizen:metadata key="http://samsung.com/tv/metadata/pkgid" value="com.samsung.tv.cobalt"/>
+    <tizen:metadata key="http://samsung.com/tv/metadata/nativeID" value="com.samsung.tv.cobalt-yt"/>
+    <tizen:metadata key="http://samsung.com/tv/metadata/native.userdata" value="--base_url=https://www.youtube.com/tv --proxy=http://127.0.0.2:8099 --content=/home/owner/share/tube/cobalt-content --dial_name=Tube --use_eden"/>
+
     <!-- Must stay true: false terminates the app on focus loss rather than hiding it, so
          Home and Back re-run the boot screen instead of returning to the video. -->
     <tizen:metadata key="http://samsung.com/tv/metadata/multitasking.support" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/voice.support" value="false"/>
 
-    <tizen:metadata key="http://tizen.org/metadata/app_ui_type/base_screen_resolution" value="fullscreen"/>
+    <tizen:metadata key="http://tizen.org/metadata/app_ui_type/base_screen_resolution" value="hybrid"/>
 
     <tizen:metadata key="http://samsung.com/tv/metadata/devel.api.version" value="5.5"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/allow.mixedcontent" value="true"/>
@@ -40,7 +55,13 @@
     <tizen:setting screen-orientation="landscape" context-menu="enable" background-support="disable" encryption="disable" install-location="auto" hwkey-event="enable"/>
     <tizen:profile name="tv-samsung"/>
 
-    <tizen:service id="tUb3Xq7Lm9.TubeService">
+
+    <!-- auto-restart and on-boot are what bring the service back when the set wakes from standby —
+         observed directly: a new pid appears in service.log on resume, and without them nothing
+         would start it, because a package carrying nativeID never runs its own content. They are
+         documented as restricted to platform and partner signed packages, and this set holds a
+         partner pair, so whether they work on an ordinary public one is still an open question. -->
+    <tizen:service id="9Ur5IzDKqV.TubeService" auto-restart="true" on-boot="true">
         <tizen:content src="service/dist/index.js"/>
         <tizen:name>TubeService</tizen:name>
         <tizen:description>The proxy and userscript injection.</tizen:description>

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,29 @@ imported locales (~375KB, now fetched on demand), `esprima` + `estraverse`
 shipped for four call sites (~150KB, replaced by a marker-anchored scan), and a
 static language-name map (33KB, now `Intl.DisplayNames`).
 
+**Inside Samsung's Cobalt container.** The set ships a second YouTube runtime —
+Cobalt, in `com.samsung.tv.cobalt` — and it is the stack that plays 2160p60 VP9
+HDR properly, which the webview does not. A package can claim its slot through
+three metadata keys: `pkgid` names the container, `nativeID` names the slot, and
+`native.userdata` carries the switches it is started with. The slot carries
+`read.metadata.from.hybrid.webapp`, so it takes those switches from the webapp
+it is paired to, and `nativeID` cannot be dropped to keep our own content
+running as well — a package carrying it never runs its own content at all, which
+is why `auto-restart` and `on-boot` are what start the service.
+
+`--proxy` names `127.0.0.2`, which is a fixed way of writing "this television"
+on every television: one package cannot reach another's `127.0.0.1` on this
+platform (`EHOSTUNREACH`), while any other loopback address connects, so there
+is no DNS and nothing per-set. `--content` names a writable copy of Cobalt's own
+content directory, staged on first run — about 5.1MB, nearly all of it
+`icu/icudt68l.dat` — because the certificate authority has to go inside it and
+the stock one is read-only.
+
+Not every Tizen device has the container; a Smart Monitor is not a television.
+On one that does not, the metadata hands the launch to something absent and
+nothing ever starts. `TUBE_COBALT_CONTAINER=off npm run package` drops the three
+keys and the app is the ordinary Chromium one again, boot screen and all.
+
 **The CDN is never on the critical path.** The bundle is inside the `.wgt`.
 On launch `latest.json` is checked in the background; a newer bundle is
 SHA-256-verified against the manifest before it is written anywhere; load order

--- a/service/index.js
+++ b/service/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const os = require('os');
+
 const postmortem = require('./lib/postmortem.js');
 postmortem.watch();
 
@@ -9,7 +11,27 @@ const proxy = require('./lib/proxy.js');
 const devbridge = require('./lib/devbridge.js');
 const forward = require('./lib/forward.js');
 
+// Guarded, and the guard is the point. Everything the container route needs is a convenience laid
+// on a proxy that has to start regardless.
+function cobaltIfItLoads() {
+    try {
+        return require('./lib/cobalt.js');
+    } catch (e) {
+        postmortem.note('cobalt', `module would not load: ${postmortem.describe(e)}`);
+        return null;
+    }
+}
+
+const cobalt = cobaltIfItLoads();
+
 const isTV = typeof tizen !== 'undefined';
+
+// With the container metadata in place the platform launches Cobalt and never runs our own
+// content, so the boot screen is unreachable and nothing speaks to the routes below that only it
+// used. A package built with TUBE_COBALT_CONTAINER=off carries no such metadata and still boots
+// through the screen.
+const containerRoute = cobalt ? cobalt.container() : null;
+const servesBootScreen = !containerRoute;
 
 const platformVersion = isTV
     ? tizen.systeminfo.getCapability('http://tizen.org/feature/platform.version')
@@ -17,61 +39,115 @@ const platformVersion = isTV
 
 const app = proxy.create();
 
+// Cobalt treats a document that arrived without a Content-Security-Policy as "deny everything",
+// which on screen is a black rectangle and a network error naming nothing. But which policies it
+// will parse differs by version, and one it refuses denies just as thoroughly — a set that
+// fetches the page over and over without running it is the symptom. Switchable at runtime so that
+// can be settled in a minute: /__tube/dev/csp?policy=wide|plain|none
+const POLICIES = {
+    wide: [
+        "default-src * data: blob: 'unsafe-inline' 'unsafe-eval'",
+        'img-src * data: blob:',
+        'media-src * data: blob:',
+        "script-src * data: blob: 'unsafe-inline' 'unsafe-eval'",
+        "style-src * data: blob: 'unsafe-inline'",
+        'connect-src *',
+        'font-src * data:'
+    ].join('; '),
+
+    // The same permission without data: or blob:, in case an older parser chokes on a scheme
+    // source in default-src and denies the lot.
+    plain: "default-src *; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline'",
+
+    none: null
+};
+
 const UPDATE_CHECK_INTERVAL = 15 * 60 * 1000;
 
-let lastUpdateCheck = 0;
-let updateInFlight = false;
+const state = { policy: 'wide', lastUpdateCheck: 0, updateInFlight: false };
 
-function maybeCheckForUpdate() {
+app.use((_, res, next) => {
+    const chosen = POLICIES[state.policy];
+
+    if (chosen) res.setHeader('Content-Security-Policy', chosen);
+    else res.removeHeader('Content-Security-Policy');
+
+    next();
+});
+
+// Checking for an update must never be able to fail the route that triggers it. A throw before
+// the promise exists used to leave `updateInFlight` set for the life of the process — one bad
+// call and no set ever checked again, while /__tube/state answered 500 to whatever asked.
+const maybeCheckForUpdate = () => {
     const now = Date.now();
-    if (updateInFlight || now - lastUpdateCheck < UPDATE_CHECK_INTERVAL) return;
+    if (state.updateInFlight || now - state.lastUpdateCheck < UPDATE_CHECK_INTERVAL) return;
 
-    lastUpdateCheck = now;
-    updateInFlight = true;
-    loader.checkForUpdate().then(
-        () => { updateInFlight = false; },
-        () => { updateInFlight = false; }
-    );
-}
+    state.lastUpdateCheck = now;
+    state.updateInFlight = true;
 
-function describeScript() {
+    const settle = () => { state.updateInFlight = false; };
+
     try {
-        const { version, origin } = loader.resolve();
-        return { version, origin };
-    } catch (e) {
-        return { error: e.message };
+        loader.checkForUpdate().then(settle, (error) => {
+            postmortem.note('update', error);
+            settle();
+        });
+    } catch (error) {
+        postmortem.note('update', error);
+        settle();
     }
-}
+};
 
-function describeState() {
+const describeState = () => {
+    const theScriptThisSetWouldRun = () => {
+        try {
+            const resolved = loader.resolve();
+            return { version: resolved.version, origin: resolved.origin };
+        } catch (e) {
+            return { error: e.message };
+        }
+    };
+
     return {
+        script: theScriptThisSetWouldRun(),
         platformVersion,
-        script: describeScript(),
+        // Which container slot this build claims, if any. Reported for diagnosis: it is what
+        // decides whether our own content ever runs.
+        container: containerRoute,
         proxyUrl: `http://localhost:${ports.PROXY}/tv`
     };
-}
+};
 
 app.get('/__tube/state', (_, res) => {
     maybeCheckForUpdate();
     res.json(describeState());
 });
 
+// The postmortem log over the network. Inside the container there is no console and no dev bridge,
+// so on those sets this is the only way to find out what the service did.
 app.get('/__tube/log', (_, res) => {
     res.type('text/plain').send(postmortem.read() || '(nothing logged)');
 });
 
-app.get('/__tube/booted', (req, res) => {
-    const line = String((req.query && req.query.t) || '').replace(/[\r\n]+/g, ' ').slice(0, 300);
+if (servesBootScreen) {
+    app.get('/__tube/booted', (req, res) => {
+        postmortem.note('boot', String((req.query && req.query.t) || '').replace(/[\r\n]+/g, ' ').slice(0, 300));
+        res.json({ ok: true });
+    });
 
-    postmortem.note('boot', line);
-    res.json({ ok: true });
-});
+    app.get('/__tube/quit', (_, res) => {
+        postmortem.note('quit', 'asked to stop by the boot screen');
+        res.json({ ok: true });
 
-app.get('/__tube/quit', (_, res) => {
-    postmortem.note('quit', 'asked to stop by the boot screen');
-    res.json({ ok: true });
+        setTimeout(() => process.exit(0), 100);
+    });
+}
 
-    setTimeout(() => process.exit(0), 100);
+app.get('/__tube/dev/csp', (req, res) => {
+    const asked = String((req.query && req.query.policy) || '');
+    if (Object.prototype.hasOwnProperty.call(POLICIES, asked)) state.policy = asked;
+
+    res.json({ policy: state.policy, sends: POLICIES[state.policy] });
 });
 
 // Which experiment flags the page is served with, changeable while the set is running:
@@ -115,45 +191,114 @@ proxy.attachFallback(app);
 const READY_PORT = 'TUBE_BOOT';
 const READY_PORT_OPEN = 'TUBE_BOOT_OPEN';
 
-function announceReady() {
-    if (!isTV) return;
+const announceReady = () => {
+    if (!isTV || !servesBootScreen) return;
 
     try {
         const uiAppId = `${tizen.application.getAppInfo().packageId}.Tube`;
         const payload = [{ key: 'state', value: JSON.stringify(describeState()) }];
-        const said = [];
 
         const send = (label, open) => {
             try {
                 open(uiAppId).sendMessage(payload);
-                said.push(`${label} sent`);
+                return `${label} sent`;
             } catch (e) {
-                said.push(`${label} ${e.name || 'Error'} ${e.message}`);
+                return `${label} ${postmortem.describe(e)}`;
             }
         };
 
-        send('trusted', (id) => tizen.messageport.requestTrustedRemoteMessagePort(id, READY_PORT));
-        send('open', (id) => tizen.messageport.requestRemoteMessagePort(id, READY_PORT_OPEN));
-
-        postmortem.note('announce', said.join(', '));
+        postmortem.note('announce', [
+            send('trusted', (id) => tizen.messageport.requestTrustedRemoteMessagePort(id, READY_PORT)),
+            send('open', (id) => tizen.messageport.requestRemoteMessagePort(id, READY_PORT_OPEN))
+        ].join(', '));
     } catch (e) {
-        postmortem.note('announce', `could not announce: ${e.name || 'Error'} ${e.message}`);
+        postmortem.note('announce', e);
+    }
+};
+
+// Loopback is not enough and is not worth trying again. Cobalt runs in its own package, and this
+// set controls app-to-app traffic on 127.0.0.1 by SMACK label: from another package 127.0.0.1 and
+// 0.0.0.0 answer EHOSTUNREACH, ::1 and localhost answer EACCES, and only the LAN address connects.
+const BIND = '0.0.0.0';
+const RETRY_LISTEN_AFTER = 5000;
+
+// Most general first. The fallbacks matter because binding every interface collides with a server
+// already on loopback — an older build of this app is the usual cause — while binding the LAN
+// address directly does not, so the two can coexist.
+const candidates = () => {
+    const interfaces = os.networkInterfaces();
+
+    return Object.keys(interfaces).reduce((found, device) => found.concat(
+        interfaces[device].filter((a) => !a.internal && a.family === 'IPv4').map((a) => a.address)
+    ), [BIND]);
+};
+
+// A failed listen used to kill the service outright: nothing handled the error, the process
+// exited, auto-restart brought it back and it failed again. From outside that is indistinguishable
+// from a service the platform never launched.
+const listen = (addresses, index) => {
+    const address = addresses[index];
+    const serving = { yes: false };
+
+    const server = app.listen(ports.PROXY, address, () => {
+        serving.yes = true;
+
+        postmortem.note('listening', `${address}:${ports.PROXY}`);
+        console.log(`tube service on ${address}:${ports.PROXY}`);
+        if (!isTV) console.log('Running off-TV: proxy and userscript are live.');
+
+        announceReady();
+    });
+
+    // Cobalt's --proxy sends TLS through CONNECT; without an answer to that the container has no
+    // network at all.
+    forward.tunnel(server);
+
+    // Handled rather than fatal, and never advanced once the port is ours: a later error would
+    // otherwise start a second server beside the one already answering.
+    server.on('error', (error) => {
+        const why = error.code === 'EADDRINUSE'
+            ? 'something already holds that port — an older build of this app is the usual cause'
+            : postmortem.describe(error);
+
+        postmortem.note('listen', `${address}:${ports.PROXY} — ${why}`);
+        if (serving.yes) return undefined;
+
+        const next = index + 1;
+        if (next < addresses.length) return listen(addresses, next);
+
+        // Wait for whatever holds it to go away rather than exiting, which would only be restarted
+        // into the same failure.
+        return setTimeout(() => listen(candidates(), 0), RETRY_LISTEN_AFTER);
+    });
+};
+
+listen(candidates(), 0);
+
+// Tizen's own service runner calls these on our exports — service_runner.js:152 calls
+// `app.onRequest()` on every wake message. Exporting nothing makes that a TypeError, which lands
+// in the uncaught handler and kills the service on any set whose runner sends one.
+module.exports = {
+    onStart: () => {},
+
+    // The platform wakes the service when the app is launched, which is the only notice anything
+    // of ours gets that a viewer opened it: the container is started instead of our content, so no
+    // page of ours runs.
+    onRequest: () => {
+        if (!cobalt) return;
+        try { cobalt.wake(); } catch (e) { postmortem.note('cobalt', e); }
+    },
+
+    onStop: () => {}
+};
+
+// Staging a directory and issuing a certificate must not be able to stop the proxy answering.
+if (cobalt) {
+    try {
+        cobalt.prepare();
+    } catch (e) {
+        postmortem.note('cobalt', `prepare threw: ${postmortem.describe(e)}`);
     }
 }
-
-const BIND = process.env.TUBE_PROXY_HOST ? '0.0.0.0' : '127.0.0.1';
-
-const server = app.listen(ports.PROXY, BIND, () => {
-    console.log(`tube service on 127.0.0.1:${ports.PROXY}`);
-    if (!isTV) {
-        console.log('Running off-TV: proxy and userscript are live.');
-    }
-
-    announceReady();
-});
-
-// A forward proxy sends TLS through CONNECT; without an answer to that a client pointed here has
-// no network at all.
-forward.tunnel(server);
 
 setTimeout(maybeCheckForUpdate, 5000);

--- a/service/index.js
+++ b/service/index.js
@@ -39,11 +39,8 @@ const platformVersion = isTV
 
 const app = proxy.create();
 
-// Cobalt treats a document that arrived without a Content-Security-Policy as "deny everything",
-// which on screen is a black rectangle and a network error naming nothing. But which policies it
-// will parse differs by version, and one it refuses denies just as thoroughly — a set that
-// fetches the page over and over without running it is the symptom. Switchable at runtime so that
-// can be settled in a minute: /__tube/dev/csp?policy=wide|plain|none
+// Cobalt denies a document that arrives without a Content-Security-Policy, and which policies it
+// accepts varies by version.
 const POLICIES = {
     wide: [
         "default-src * data: blob: 'unsafe-inline' 'unsafe-eval'",
@@ -55,8 +52,6 @@ const POLICIES = {
         'font-src * data:'
     ].join('; '),
 
-    // The same permission without data: or blob:, in case an older parser chokes on a scheme
-    // source in default-src and denies the lot.
     plain: "default-src *; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline'",
 
     none: null
@@ -75,9 +70,7 @@ app.use((_, res, next) => {
     next();
 });
 
-// Checking for an update must never be able to fail the route that triggers it. A throw before
-// the promise exists used to leave `updateInFlight` set for the life of the process — one bad
-// call and no set ever checked again, while /__tube/state answered 500 to whatever asked.
+// Checking for an update must never be able to fail the route that triggers it.
 const maybeCheckForUpdate = () => {
     const now = Date.now();
     if (state.updateInFlight || now - state.lastUpdateCheck < UPDATE_CHECK_INTERVAL) return;
@@ -192,10 +185,10 @@ const READY_PORT = 'TUBE_BOOT';
 const READY_PORT_OPEN = 'TUBE_BOOT_OPEN';
 
 const announceReady = () => {
-    if (!isTV || !servesBootScreen) return;
+    if (!isTV || !servesBootScreen || !cobalt) return;
 
     try {
-        const uiAppId = `${tizen.application.getAppInfo().packageId}.Tube`;
+        const uiAppId = cobalt.appId();
         const payload = [{ key: 'state', value: JSON.stringify(describeState()) }];
 
         const send = (label, open) => {
@@ -216,15 +209,11 @@ const announceReady = () => {
     }
 };
 
-// Loopback is not enough and is not worth trying again. Cobalt runs in its own package, and this
-// set controls app-to-app traffic on 127.0.0.1 by SMACK label: from another package 127.0.0.1 and
-// 0.0.0.0 answer EHOSTUNREACH, ::1 and localhost answer EACCES, and only the LAN address connects.
+// Every interface, because the container is another package and cannot reach our 127.0.0.1.
 const BIND = '0.0.0.0';
 const RETRY_LISTEN_AFTER = 5000;
 
-// Most general first. The fallbacks matter because binding every interface collides with a server
-// already on loopback — an older build of this app is the usual cause — while binding the LAN
-// address directly does not, so the two can coexist.
+// Fallbacks, because a LAN address still binds while another server holds the port on loopback.
 const candidates = () => {
     const interfaces = os.networkInterfaces();
 
@@ -233,9 +222,6 @@ const candidates = () => {
     ), [BIND]);
 };
 
-// A failed listen used to kill the service outright: nothing handled the error, the process
-// exited, auto-restart brought it back and it failed again. From outside that is indistinguishable
-// from a service the platform never launched.
 const listen = (addresses, index) => {
     const address = addresses[index];
     const serving = { yes: false };
@@ -275,9 +261,7 @@ const listen = (addresses, index) => {
 
 listen(candidates(), 0);
 
-// Tizen's own service runner calls these on our exports — service_runner.js:152 calls
-// `app.onRequest()` on every wake message. Exporting nothing makes that a TypeError, which lands
-// in the uncaught handler and kills the service on any set whose runner sends one.
+// Tizen's service runner calls these on every wake message, and a missing one kills the service.
 module.exports = {
     onStart: () => {},
 

--- a/service/lib/cobalt.js
+++ b/service/lib/cobalt.js
@@ -14,9 +14,7 @@ const postmortem = require('./postmortem.js');
 
 const STOCK = '/usr/apps/com.samsung.tv.cobalt/content/app/cobalt/content';
 
-// Named by pkgid metadata rather than nativeID: carrying nativeID makes the launcher start the
-// container instead of our own content, so nothing is left to start the service or sequence the
-// two.
+// The nativeID this package claims, which is also the app id the launched container runs under.
 const CONTAINER = 'com.samsung.tv.cobalt-yt';
 
 const SHARE = process.env.TUBE_SHARE || '/home/owner/share/tube';
@@ -119,10 +117,7 @@ const checkAddress = () => {
     });
 };
 
-// Reopening is where this falls down: the container the platform starts on a reopen dies at once,
-// while the identical launch issued from a service works every time. Tizen calls onRequest on our
-// exports when the app is launched, so this is an event rather than a poll. The guard is only
-// against a launch storm — a viewer who closes the app must not be dragged back in.
+// Launched from the service because the container the platform starts on a reopen dies at once.
 const wake = () => {
     if (typeof tizen === 'undefined') return;
 
@@ -141,8 +136,7 @@ const wake = () => {
     }, () => {});
 };
 
-// About 5.1MB, nearly all of it icu/icudt68l.dat, and only on the first run. Same size is enough
-// to call a file done: a firmware update replaces the whole directory.
+// Same size is enough to call a file done: a firmware update replaces the whole directory.
 const copyInto = (from, to) => {
     fs.mkdirSync(to, { recursive: true });
 
@@ -248,7 +242,6 @@ const cobaltIsInstalledHere = () => {
     try { return fs.statSync(STOCK).isDirectory(); } catch (e) { return false; }
 };
 
-// About 5.1MB on the first run, then nothing.
 const stagedMaterial = (content) => {
     const copied = copyInto(STOCK, content);
     if (copied) note('staged', `${copied} files into ${content}`);
@@ -271,11 +264,12 @@ const prepare = (done) => {
         if (error) note('failed', error);
         else state.prepared = result;
 
-        const waiting = state.waiting.splice(0, state.waiting.length);
+        const waiting = state.waiting;
+        state.waiting = [];
         return waiting.forEach((waiter) => waiter(error, result));
     };
 
-    if (done) state.waiting.push(done);
+    if (done) state.waiting = state.waiting.concat([done]);
 
     if (state.prepared) return done ? done(null, state.prepared) : undefined;
 
@@ -336,4 +330,4 @@ const material = () => {
     return { key: existing.key, cert: existing.chain };
 };
 
-module.exports = { prepare, wake, material, container, MITM_DIR };
+module.exports = { prepare, wake, material, container, appId, MITM_DIR };

--- a/service/lib/cobalt.js
+++ b/service/lib/cobalt.js
@@ -1,0 +1,339 @@
+'use strict';
+
+// Everything the container route needs that a package cannot carry, derived on the set: a
+// writable copy of Cobalt's content directory, and the certificate authority that sits in it.
+// One CA baked into a public release would put its private key in every download.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const dns = require('dns');
+
+const x509 = require('./x509.js');
+const postmortem = require('./postmortem.js');
+
+const STOCK = '/usr/apps/com.samsung.tv.cobalt/content/app/cobalt/content';
+
+// Named by pkgid metadata rather than nativeID: carrying nativeID makes the launcher start the
+// container instead of our own content, so nothing is left to start the service or sequence the
+// two.
+const CONTAINER = 'com.samsung.tv.cobalt-yt';
+
+const SHARE = process.env.TUBE_SHARE || '/home/owner/share/tube';
+const MITM_DIR = process.env.TUBE_MITM_DIR || path.join(SHARE, 'mitm');
+
+const CONFIG = path.join(__dirname, '..', '..', 'config.xml');
+
+// googlevideo is deliberately absent: media is a blind tunnel, and standing in front of it buys
+// nothing but latency.
+const HOSTS = [
+    'youtube.com', '*.youtube.com',
+    'google.com', '*.google.com',
+    'googleapis.com', '*.googleapis.com',
+    'gstatic.com', '*.gstatic.com',
+    'ggpht.com', '*.ggpht.com'
+];
+
+const REISSUE_WITHIN = 30 * 86400000;
+const RELAUNCH_QUIET = 20000;
+
+// OpenSSL steps <hash>.0, .1, .2 … when a name collides.
+const SLOTS = 8;
+
+const note = (what, detail) => postmortem.note('cobalt', `${what}: ${postmortem.describe(detail)}`);
+
+const state = { config: undefined, prepared: null, preparing: false, lastWake: 0, waiting: [] };
+
+const config = () => {
+    if (state.config === undefined) {
+        try {
+            state.config = fs.readFileSync(CONFIG, 'utf8');
+        } catch (e) {
+            state.config = null;
+        }
+    }
+
+    return state.config;
+};
+
+// Our own switches, so the staging lands where --content says rather than by convention.
+const switches = () => {
+    const found = /native\.userdata"\s+value="([^"]*)"/.exec(config() || '');
+    return found ? found[1].replace(/&quot;/g, '"') : null;
+};
+
+const configuredContent = () => {
+    if (process.env.TUBE_COBALT_CONTENT) return process.env.TUBE_COBALT_CONTENT;
+
+    const found = /--content=(\S+)/.exec(switches() || '');
+    return found ? found[1] : null;
+};
+
+// The container slot this package claims, or null when it claims none.
+const container = () => {
+    if (config() === null) return null;
+
+    return /--content=|--base_url=/.test(switches() || '') ? CONTAINER : null;
+};
+
+const appId = () => {
+    const found = /<tizen:application\s+id="([^"]+)"/.exec(config() || '');
+    return found ? found[1] : null;
+};
+
+const addresses = () => {
+    const interfaces = os.networkInterfaces();
+
+    return Object.keys(interfaces).reduce(
+        (all, device) => all.concat(interfaces[device].map((entry) => entry.address)), []
+    );
+};
+
+// Loopback is this set, whichever loopback it is. The switch names 127.0.0.2 precisely because
+// that is a fixed way of saying "here" — only 127.0.0.1 appears in the interface list, so
+// comparing against that alone reports the one configuration that is always right as misdirected.
+const isLoopback = (address) => address === '::1' || String(address).indexOf('127.') === 0;
+
+// Cobalt resolves the set's own hostname, which leans on the router registering DHCP names. When
+// it does not, the alternative is a silent network error with nothing anywhere to explain it.
+const checkAddress = () => {
+    const named = /--proxy=http:\/\/([^:\s]+)/.exec(switches() || '');
+    if (!named) return;
+
+    const mine = addresses();
+    const here = `This set is ${os.hostname()} at ${mine.join(', ')}.`;
+
+    dns.lookup(named[1], { all: true }, (error, found) => {
+        if (error) {
+            return note('unreachable', `--proxy names ${named[1]}, which does not resolve here `
+                + `(${error.code}). ${here}`);
+        }
+
+        const resolved = found.map((entry) => entry.address);
+        const ours = (address) => isLoopback(address) || mine.indexOf(address) !== -1;
+
+        if (resolved.some(ours)) return undefined;
+
+        return note('misdirected', `--proxy names ${named[1]}, which resolves to `
+            + `${resolved.join(', ')} — not this set. ${here}`);
+    });
+};
+
+// Reopening is where this falls down: the container the platform starts on a reopen dies at once,
+// while the identical launch issued from a service works every time. Tizen calls onRequest on our
+// exports when the app is launched, so this is an event rather than a poll. The guard is only
+// against a launch storm — a viewer who closes the app must not be dragged back in.
+const wake = () => {
+    if (typeof tizen === 'undefined') return;
+
+    const me = appId();
+    if (!me || !container()) return;
+
+    const now = Date.now();
+    if (now - state.lastWake < RELAUNCH_QUIET) return;
+    state.lastWake = now;
+
+    tizen.application.getAppsContext((contexts) => {
+        if (contexts.some((context) => context.appId === CONTAINER)) return;
+
+        note('woken', `the container is not up; launching ${me}`);
+        tizen.application.launch(me, () => {}, (error) => note('relaunch', `refused: ${error.message}`));
+    }, () => {});
+};
+
+// About 5.1MB, nearly all of it icu/icudt68l.dat, and only on the first run. Same size is enough
+// to call a file done: a firmware update replaces the whole directory.
+const copyInto = (from, to) => {
+    fs.mkdirSync(to, { recursive: true });
+
+    return fs.readdirSync(from).reduce((copied, entry) => {
+        const source = path.join(from, entry);
+        const target = path.join(to, entry);
+        const info = fs.statSync(source);
+
+        if (info.isDirectory()) return copied + copyInto(source, target);
+
+        try {
+            if (fs.statSync(target).size === info.size) return copied;
+        } catch (e) { /* absent, so copy it */ }
+
+        fs.writeFileSync(target, fs.readFileSync(source));
+        return copied + 1;
+    }, 0);
+};
+
+const read = (file) => fs.readFileSync(path.join(MITM_DIR, file), 'utf8');
+
+const existingMaterial = () => {
+    try {
+        return { ca: JSON.parse(read('ca.json')), key: read('leaf.key'), chain: read('leaf-chain.crt') };
+    } catch (e) {
+        return null;
+    }
+};
+
+// Reissue well before the cliff, and whenever the set of names has changed.
+const stillGood = (material) => {
+    try {
+        const cert = new (require('crypto').X509Certificate)(material.chain);
+        const left = new Date(cert.validTo).getTime() - Date.now();
+        const names = (cert.subjectAltName || '').replace(/DNS:/g, '').split(', ').sort().join();
+
+        return left > REISSUE_WITHIN && names === HOSTS.slice().sort().join();
+    } catch (e) {
+        // No X509Certificate before Node 15. Trusting what is on disk beats refusing to run.
+        return true;
+    }
+};
+
+const issue = (done) => {
+    const commonName = `Tube Local CA (${os.hostname()})`;
+
+    x509.createCa(commonName, (error, ca) => {
+        if (error) return done(error);
+
+        return x509.createLeaf(ca, 'www.youtube.com', HOSTS, (leafError, leaf) => {
+            if (leafError) return done(leafError);
+
+            try {
+                fs.mkdirSync(MITM_DIR, { recursive: true });
+                fs.writeFileSync(path.join(MITM_DIR, 'ca.crt'), ca.cert);
+                fs.writeFileSync(path.join(MITM_DIR, 'ca.json'), JSON.stringify({ commonName, cert: ca.cert }));
+                fs.writeFileSync(path.join(MITM_DIR, 'leaf-chain.crt'), leaf.chain);
+                fs.writeFileSync(path.join(MITM_DIR, 'leaf.key'), leaf.key, { mode: 0o600 });
+            } catch (writeError) {
+                return done(writeError);
+            }
+
+            note('issued', commonName);
+            return done(null, { ca: { commonName, cert: ca.cert }, key: leaf.key, chain: leaf.chain });
+        });
+    });
+};
+
+// The store is an OpenSSL hashed directory, so the file name is the lookup: <subject_hash>.0, and
+// again under -subject_hash_old because which is used depends on how the verifier was built. A
+// name off by a byte is indistinguishable from an absent CA.
+const installCa = (certs, ca) => {
+    fs.mkdirSync(certs, { recursive: true });
+
+    const contentsOf = (file) => {
+        try { return fs.readFileSync(file, 'utf8'); } catch (e) { return null; }
+    };
+
+    // A collision with one of the roots already there would be remarkable, but stepping the suffix
+    // is what OpenSSL itself does, and the log has to name the file it really wrote.
+    const place = (hash) => {
+        const slots = Array.from({ length: SLOTS }, (_, suffix) => ({
+            suffix,
+            file: path.join(certs, `${hash}.${suffix}`)
+        }));
+
+        const already = slots.find((slot) => contentsOf(slot.file) === ca.cert);
+        if (already) return `${hash}.${already.suffix} already there`;
+
+        const free = slots.find((slot) => contentsOf(slot.file) === null);
+        if (!free) return `${hash} has no free slot`;
+
+        fs.writeFileSync(free.file, ca.cert);
+        return `${hash}.${free.suffix} written`;
+    };
+
+    const hashes = x509.subjectHashes(ca.commonName);
+
+    note('trusted', `${ca.commonName} — ${[hashes.hash, hashes.hashOld].map(place).join(', ')}`);
+};
+
+const cobaltIsInstalledHere = () => {
+    try { return fs.statSync(STOCK).isDirectory(); } catch (e) { return false; }
+};
+
+// About 5.1MB on the first run, then nothing.
+const stagedMaterial = (content) => {
+    const copied = copyInto(STOCK, content);
+    if (copied) note('staged', `${copied} files into ${content}`);
+
+    return existingMaterial();
+};
+
+const stageOrFail = (content) => {
+    try {
+        return { material: stagedMaterial(content) };
+    } catch (error) {
+        return { error };
+    }
+};
+
+const prepare = (done) => {
+    const finish = (error, result) => {
+        state.preparing = false;
+
+        if (error) note('failed', error);
+        else state.prepared = result;
+
+        const waiting = state.waiting.splice(0, state.waiting.length);
+        return waiting.forEach((waiter) => waiter(error, result));
+    };
+
+    if (done) state.waiting.push(done);
+
+    if (state.prepared) return done ? done(null, state.prepared) : undefined;
+
+    // Held rather than answered: telling a caller "finished, nothing to do" while the work is
+    // still running reports an empty result as a real one.
+    if (state.preparing) return undefined;
+
+    state.preparing = true;
+
+    // Reported either way and before anything else: on a set the service cannot be reached from,
+    // this one line is the whole diagnosis. Not every Tizen device has the container.
+    const present = cobaltIsInstalledHere();
+
+    note(present ? 'present' : 'absent', present
+        ? `Cobalt is at ${STOCK}`
+        : `nothing at ${STOCK} — ${os.hostname()} may not be a device that has the container`);
+
+    const content = configuredContent();
+    if (!content) return finish(null, null);
+
+    checkAddress();
+
+    if (!present) return finish(null, null);
+
+    const staged = stageOrFail(content);
+    if (staged.error) return finish(staged.error);
+
+    const material = staged.material;
+
+    const trust = (issued) => {
+        try {
+            installCa(path.join(content, 'ssl', 'certs'), issued.ca);
+        } catch (e) {
+            return finish(e);
+        }
+
+        return finish(null, issued);
+    };
+
+    if (material && stillGood(material)) return trust(material);
+
+    // Key generation is seconds on this hardware, so it runs off the event loop and the service
+    // answers normally while it happens.
+    if (!x509.available()) return finish(null, null);
+
+    return issue((error, issued) => (error ? finish(error) : trust(issued)));
+};
+
+// What forward.js needs to stand in front of a TLS connection, or null while it is still being
+// made. Read from disk so a service that started before the staging finished picks it up.
+const material = () => {
+    if (state.prepared) return { key: state.prepared.key, cert: state.prepared.chain };
+
+    const existing = existingMaterial();
+    if (!existing) return null;
+
+    state.prepared = existing;
+    return { key: existing.key, cert: existing.chain };
+};
+
+module.exports = { prepare, wake, material, container, MITM_DIR };

--- a/tools/package.js
+++ b/tools/package.js
@@ -39,6 +39,106 @@ function stageContents(staging) {
     });
 }
 
+// TUBE_GAME_MODE=1 npm run package. use.game.mode is what makes the renderer count frames — a
+// pristine getVideoPlaybackQuality reads 0/0/0 otherwise — and is said to cost frames, so a
+// package built with it is for measuring and not for watching. Added to the staged copy, so the
+// file in the repository stays the file that ships.
+const GAME_MODE = '<tizen:metadata key="http://samsung.com/tv/metadata/use.game.mode" value="true"/>';
+
+const wantsGameMode = () => process.env.TUBE_GAME_MODE === '1';
+
+const xmlAttribute = (value) => String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+// Not every Tizen device has the container — a Smart Monitor is not a television — and on one that
+// does not, the metadata hands the launch to something absent, our own content never runs, and
+// nothing starts the service. TUBE_COBALT_CONTAINER=off drops the three keys and the app is the
+// ordinary Chromium one again.
+function withoutContainer(staging) {
+    if (process.env.TUBE_COBALT_CONTAINER !== 'off') return;
+
+    const path = join(staging, 'config.xml');
+    const keys = ['pkgid', 'nativeID', 'native.userdata'];
+
+    const xml = keys.reduce((text, key) => text.replace(
+        new RegExp(`\\s*<tizen:metadata\\s+key="http://samsung\\.com/tv/metadata/${key}"[^>]*/>`), ''
+    ), readFileSync(path, 'utf8'));
+
+    keys.forEach((key) => {
+        if (xml.indexOf(`metadata/${key}"`) !== -1) throw friendly(`Could not remove the ${key} metadata.`);
+    });
+
+    writeFileSync(path, xml);
+}
+
+function addCobaltProfile(staging) {
+    if (process.env.TUBE_COBALT_CONTAINER === 'off') return;
+
+    const baseUrl = process.env.TUBE_COBALT_BASE_URL;
+    const proxyUrl = process.env.TUBE_COBALT_PROXY;
+    const content = process.env.TUBE_COBALT_CONTENT;
+    if (!baseUrl && !proxyUrl && !content) return;
+    if (!baseUrl || !proxyUrl) {
+        throw friendly('TUBE_COBALT_BASE_URL and TUBE_COBALT_PROXY must be supplied together.');
+    }
+    if (content && /[\s"&<>]/.test(content)) {
+        throw friendly('TUBE_COBALT_CONTENT must be a path without whitespace or XML characters.');
+    }
+    // --content replaces the Evergreen content directory wholesale, so it names the directory that
+    // directly holds fonts/, icu/, licenses/ and ssl/certs/ — not the loader root above it.
+    if (content && /\/app\/cobalt$|\/app$/.test(content)) {
+        throw friendly(
+            'TUBE_COBALT_CONTENT names the Evergreen content directory itself, not the tree above\n' +
+            `  it. ${content}/content is probably what you meant.`
+        );
+    }
+
+    const checkUrl = (name, value, scheme) => {
+        const parsed = (() => {
+            try { return new URL(value); } catch (e) { return null; }
+        })();
+
+        if (!parsed) throw friendly(`${name} is not a URL: ${value}`);
+        if (parsed.protocol !== scheme) throw friendly(`${name} must use ${scheme.slice(0, -1)}.`);
+    };
+
+    checkUrl('TUBE_COBALT_BASE_URL', baseUrl, 'https:');
+    checkUrl('TUBE_COBALT_PROXY', proxyUrl, 'http:');
+
+    const path = join(staging, 'config.xml');
+    const xml = readFileSync(path, 'utf8');
+    const metadata = 'http://samsung.com/tv/metadata/native.userdata';
+    const expression = new RegExp(`(<tizen:metadata\\s+key="${metadata}"\\s+value=")([^"]*)("\\s*/>)`);
+    if (!expression.test(xml)) throw friendly('config.xml has no Cobalt native.userdata metadata.');
+
+    // Only --base_url, --proxy and --content are this profile's business. Replacing the whole
+    // switch list drops --use_eden and --dial_name, and without those the container reports a
+    // successful launch and then never appears in getAppsContext at all.
+    const existing = expression.exec(xml)[2].split(/\s+/).filter(Boolean)
+        .filter((argument) => !/^--(base_url|proxy|content)=/.test(argument));
+
+    const args = [
+        `--base_url=${baseUrl}`,
+        `--proxy=${proxyUrl}`,
+        content ? `--content=${content}` : null,
+        ...existing
+    ].filter(Boolean).join(' ');
+
+    writeFileSync(path, xml.replace(expression, `$1${xmlAttribute(args)}$3`));
+}
+
+function addGameMode(staging) {
+    const path = join(staging, 'config.xml');
+    const xml = readFileSync(path, 'utf8');
+
+    if (xml.indexOf('metadata/use.game.mode"') !== -1) return;
+
+    writeFileSync(path, xml.replace('</widget>', `    ${GAME_MODE}\n</widget>`));
+}
+
 async function writeWidget(staging, outPath) {
     const zip = new JSZip();
 
@@ -64,6 +164,9 @@ async function packageApp() {
     const started = Date.now();
     try {
         stageContents(staging);
+        addCobaltProfile(staging);
+        withoutContainer(staging);
+        if (wantsGameMode()) addGameMode(staging);
         await writeWidget(staging, outPath);
     } finally {
         rmSync(staging, { recursive: true, force: true });
@@ -77,6 +180,7 @@ async function main() {
     const config = load({ requireReal: release });
 
     ui.heading('package', `v${config.version}`);
+    if (wantsGameMode()) ui.note(ui.style.dim('  use.game.mode is on: a package for measuring, not for watching.'));
     ui.note(ui.style.dim('  building first...'));
     execFileSync('node', [join(__dirname, 'build.js')], { cwd: ROOT, stdio: 'inherit' });
 

--- a/tools/package.js
+++ b/tools/package.js
@@ -39,10 +39,7 @@ function stageContents(staging) {
     });
 }
 
-// TUBE_GAME_MODE=1 npm run package. use.game.mode is what makes the renderer count frames — a
-// pristine getVideoPlaybackQuality reads 0/0/0 otherwise — and is said to cost frames, so a
-// package built with it is for measuring and not for watching. Added to the staged copy, so the
-// file in the repository stays the file that ships.
+// use.game.mode is what makes getVideoPlaybackQuality count frames at all.
 const GAME_MODE = '<tizen:metadata key="http://samsung.com/tv/metadata/use.game.mode" value="true"/>';
 
 const wantsGameMode = () => process.env.TUBE_GAME_MODE === '1';

--- a/ui/src/boot.js
+++ b/ui/src/boot.js
@@ -387,6 +387,8 @@ const boot = async () => {
     return useProxy(reached.state);
 };
 
+// This screen only ever runs in a build without the container metadata: a package carrying
+// nativeID never runs its own content, and the platform launches Cobalt in its place.
 const useProxy = (state) => {
     const target = (state && state.proxyUrl) || localProxyUrl();
 


### PR DESCRIPTION
The set already carries a second YouTube runtime, and it is the better one: the
Chromium webview tops out where Cobalt plays 2160p60 VP9 HDR properly. A package
can claim its slot through three metadata keys — `pkgid` names the container,
`nativeID` names the slot, and `native.userdata` carries the switches — and the
service then stands in front of it as the proxy those switches point at.

Two dead ends are recorded in config.xml so they are not tried again.
`prelaunch.support` false was tried against the reopen-after-force-close failure
and made it worse: the app then would not start even the first time. And
`nativeID` cannot be dropped to keep our own content running as well — the slot
carries `read.metadata.from.hybrid.webapp`, so it takes its switches from the
webapp it is paired to, and without the pairing the container arrives with none
of them. That also means this package never runs its own content, which is why
the service is declared `auto-restart` and `on-boot`: nothing else would start
it, and a new pid does appear in the log when the set wakes from standby.

`--proxy` names 127.0.0.2 rather than a hostname or an address. Loopback is not
enough and is not worth trying again: from another package on this platform
127.0.0.1 and 0.0.0.0 answer EHOSTUNREACH and ::1 and localhost answer EACCES,
while any other loopback address connects — so 127.0.0.2 is a fixed string
meaning "this television" on every television, with no DNS and nothing per-set.
`--content` has to name the Evergreen content directory itself and not the tree
above it, and it is a copy staged on the set, because the certificate authority
goes inside it and the stock one is read-only.

`cobalt.js` does the deriving: it stages that copy, issues the CA if there is
none or the names have changed, installs it under both OpenSSL subject hashes
because which one is used depends on how the verifier was built, and relaunches
the container on `onRequest` — the container the platform starts on a reopen
dies at once, while the identical launch issued from a service works every time.
A document that reaches Cobalt without a CSP is treated as "deny everything", so
one is added, switchable at runtime because which policies it will parse differs
by version and a refused policy denies just as thoroughly.

None of it is allowed to stop the proxy answering: the module is required behind
a guard, `prepare()` is wrapped, and a package built with
TUBE_COBALT_CONTAINER=off carries none of the metadata and is the ordinary
Chromium app again — which is what a Smart Monitor needs, since not every Tizen
device has the container at all.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>