### PR TITLE
Take back our own package id, and stop squatting stock YouTube's

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns:tizen="http://tizen.org/ns/widgets" xmlns="http://www.w3.org/ns/widgets" id="https://tube.local" version="0.4.0" viewmodes="maximized">
     <access origin="*" subdomains="true"></access>
     <tizen:allow-navigation href="*"/>
-    <tizen:application id="9Ur5IzDKqV.TizenYouTube" package="9Ur5IzDKqV" required_version="5.0"/>
+    <tizen:application id="tUb3Xq7Lm9.Tube" package="tUb3Xq7Lm9" required_version="5.0"/>
     <author>tube</author>
     <content src="ui/dist/index.html"/>
     <feature name="http://tizen.org/feature/screen.size.all"/>
@@ -19,6 +19,13 @@
     <tizen:metadata key="http://samsung.com/tv/metadata/no_use_process_pool" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/html5.4k.support" value="true"/>
 
+    <!-- The slot itself supplies nothing — it carries only read.metadata.from.hybrid.webapp — and
+         several webapps may claim the same one: the switches come from whichever webapp was
+         launched. Stock YouTube is the Samsung store app 9Ur5IzDKqV.TizenYouTube, which claims
+         this same cobalt-yt and supplies the same base_url switch with no proxy switch. So this
+         package is its counterpart rather than its replacement: both installed, each icon starts
+         the container with its own switches and neither disturbs the other. Verified on hardware
+         2026-09-06, which also settles that the claim is not bound to a particular package id. -->
     <!-- proxy names 127.0.0.2 because the container, another package, cannot reach this one's 127.0.0.1. -->
     <tizen:metadata key="http://samsung.com/tv/metadata/pkgid" value="com.samsung.tv.cobalt"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/nativeID" value="com.samsung.tv.cobalt-yt"/>
@@ -49,7 +56,7 @@
 
     <!-- Without auto-restart and on-boot nothing restarts the service after standby, because a
          package carrying nativeID never runs its own content. -->
-    <tizen:service id="9Ur5IzDKqV.TubeService" auto-restart="true" on-boot="true">
+    <tizen:service id="tUb3Xq7Lm9.TubeService" auto-restart="true" on-boot="true">
         <tizen:content src="service/dist/index.js"/>
         <tizen:name>TubeService</tizen:name>
         <tizen:description>The proxy and userscript injection.</tizen:description>

--- a/config.xml
+++ b/config.xml
@@ -19,13 +19,6 @@
     <tizen:metadata key="http://samsung.com/tv/metadata/no_use_process_pool" value="true"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/html5.4k.support" value="true"/>
 
-    <!-- The slot itself supplies nothing — it carries only read.metadata.from.hybrid.webapp — and
-         several webapps may claim the same one: the switches come from whichever webapp was
-         launched. Stock YouTube is the Samsung store app 9Ur5IzDKqV.TizenYouTube, which claims
-         this same cobalt-yt and supplies the same base_url switch with no proxy switch. So this
-         package is its counterpart rather than its replacement: both installed, each icon starts
-         the container with its own switches and neither disturbs the other. Verified on hardware
-         2026-09-06, which also settles that the claim is not bound to a particular package id. -->
     <!-- proxy names 127.0.0.2 because the container, another package, cannot reach this one's 127.0.0.1. -->
     <tizen:metadata key="http://samsung.com/tv/metadata/pkgid" value="com.samsung.tv.cobalt"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/nativeID" value="com.samsung.tv.cobalt-yt"/>

--- a/service/lib/cobalt.js
+++ b/service/lib/cobalt.js
@@ -34,6 +34,9 @@ const HOSTS = [
 
 const REISSUE_WITHIN = 30 * 86400000;
 const RELAUNCH_QUIET = 20000;
+const CLAIM_WITHIN = 10000;
+const LOOKUP_QUIET = 5000;
+const KILL_SETTLE = 1200;
 
 // OpenSSL steps <hash>.0, .1, .2 … when a name collides.
 const SLOTS = 8;
@@ -41,6 +44,7 @@ const SLOTS = 8;
 const note = (what, detail) => postmortem.note('cobalt', `${what}: ${postmortem.describe(detail)}`);
 
 const state = { config: undefined, prepared: null, preparing: false, lastWake: 0, waiting: [] };
+const proxied = { context: null, at: 0, lookedAt: 0 };
 
 const config = () => {
     if (state.config === undefined) {
@@ -117,6 +121,38 @@ const checkAddress = () => {
     });
 };
 
+const served = () => {
+    const now = Date.now();
+    proxied.at = now;
+
+    if (typeof tizen === 'undefined' || now - proxied.lookedAt < LOOKUP_QUIET) return;
+    proxied.lookedAt = now;
+
+    try {
+        tizen.application.getAppsContext((contexts) => {
+            const up = contexts.find((context) => context.appId === CONTAINER);
+            if (up) proxied.context = up.id;
+        }, () => {});
+    } catch (e) {
+        note('served', e);
+    }
+};
+
+const launch = (me) => tizen.application.launch(me, () => {},
+    (error) => note('relaunch', `refused: ${error.message}`));
+
+const replaceUnlessOurs = (up, me, since) => {
+    if (up.id === proxied.context) return;
+
+    setTimeout(() => {
+        if (proxied.at >= since) proxied.context = up.id;
+        if (up.id === proxied.context) return;
+
+        note('woken', `the container is not ours; launching ${me}`);
+        tizen.application.kill(up.id, () => setTimeout(() => launch(me), KILL_SETTLE), () => launch(me));
+    }, CLAIM_WITHIN);
+};
+
 // Launched from the service because the container the platform starts on a reopen dies at once.
 const wake = () => {
     if (typeof tizen === 'undefined') return;
@@ -129,10 +165,11 @@ const wake = () => {
     state.lastWake = now;
 
     tizen.application.getAppsContext((contexts) => {
-        if (contexts.some((context) => context.appId === CONTAINER)) return;
+        const up = contexts.find((context) => context.appId === CONTAINER);
+        if (up) return replaceUnlessOurs(up, me, now);
 
         note('woken', `the container is not up; launching ${me}`);
-        tizen.application.launch(me, () => {}, (error) => note('relaunch', `refused: ${error.message}`));
+        return launch(me);
     }, () => {});
 };
 
@@ -330,4 +367,4 @@ const material = () => {
     return { key: existing.key, cert: existing.chain };
 };
 
-module.exports = { prepare, wake, material, container, appId, MITM_DIR };
+module.exports = { prepare, wake, served, material, container, appId, MITM_DIR };

--- a/service/lib/forward.js
+++ b/service/lib/forward.js
@@ -9,6 +9,17 @@ const journal = require('./journal.js');
 const postmortem = require('./postmortem.js');
 const mitm = require('./mitm.js');
 
+// A cobalt.js that fails to load, which mitm.js notes, costs the served stamp, never the tunnel.
+function cobaltIfItLoads() {
+    try {
+        return require('./cobalt.js');
+    } catch (e) {
+        return null;
+    }
+}
+
+const cobalt = cobaltIfItLoads();
+
 const ABSOLUTE = /^https?:\/\//i;
 
 const QUIET = 60000;
@@ -51,6 +62,8 @@ const tunnel = (server) => {
     const interceptor = mitm.interceptor(server, record);
 
     server.on('connect', (req, client, head) => {
+        if (cobalt) cobalt.served();
+
         const [host, port] = req.url.split(':');
         const secure = mitm.isIntercepted(host) ? interceptor() : null;
 


### PR DESCRIPTION
Claiming the Cobalt slot only started working after `9Ur5IzDKqV.TizenYouTube`
was uninstalled and its package id taken, and the conclusion drawn was that the
slot binds to that id. Two things changed at once there, and it was the wrong
one. A slot supplies no switches at all — it carries only
`read.metadata.from.hybrid.webapp` — and several webapps may claim the same one:
what the container starts with comes from whichever webapp was launched.

`9Ur5IzDKqV.TizenYouTube` is Samsung's own store YouTube, a thin hybrid webapp
claiming this same `com.samsung.tv.cobalt-yt` with the same `--base_url` and no
`--proxy`. So we were not taking a slot from anybody; we were shipping under the
package id of the app we sit beside. Installed together, each icon starts the
container with its own switches and neither disturbs the other — verified on
hardware, our service's log naming `launching tUb3Xq7Lm9.Tube` with the
intercepted request trace behind it, while stock stayed unmodded.

Shipping under a store app's package id would have replaced YouTube on the
television of anyone who installed this, for a constraint that was never there.

It also puts `announceReady` back on its feet. It derives the boot screen's app
id as `${packageId}.Tube`, which matched `tUb3Xq7Lm9.Tube` and did not match
`9Ur5IzDKqV.TizenYouTube` — latent, because that path only runs in a
TUBE_COBALT_CONTAINER=off build, and it degraded to polling rather than failing
outright, which is why it went unnoticed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>