### PR TITLE
Leave the subscription tabs in the three groups YouTube sends

### DIFF
--- a/framework/config.js
+++ b/framework/config.js
@@ -57,7 +57,6 @@ const defaultConfig = {
   enableHideWatchedVideos: false,
   hideWatchedVideosThreshold: 80,
   hideWatchedVideosPages: [],
-  sortSubscriptionsByAlphabet: true,
 
   enablePatchingVideoPlayer: true,
   enablePreviousNextButtons: true,

--- a/mods/feed/adblock.js
+++ b/mods/feed/adblock.js
@@ -108,23 +108,21 @@ onResponse('ads and shelves', RESPONSE_KEYS, (r) => {
     }
 
     if (r?.contents?.tvBrowseRenderer?.content?.tvSecondaryNavRenderer?.sections) {
-      const selectedFirstThenByTitle = (a, b) => {
-        if (a.tabRenderer.selected && !b.tabRenderer.selected) return -1;
-        if (!a.tabRenderer.selected && b.tabRenderer.selected) return 1;
-        return a.tabRenderer.title.localeCompare(b.tabRenderer.title);
-      };
-
       const dressTab = (tab) => {
         const content = tab.tabRenderer.content?.tvSurfaceContentRenderer?.content;
         if (content?.sectionListRenderer?.contents) walkShelves(content.sectionListRenderer.contents, SHELF);
         if (content?.gridRenderer?.items) content.gridRenderer.items = walkTiles(content.gridRenderer.items, GRID);
       };
 
+      // The tabs are not one list. YouTube sends "All", then the channels with something new,
+      // then an "A-Z" divider carrying no endpoint and no content, then every channel in order.
+      // Sorting them together flattened the three into one: the divider went to its alphabetical
+      // place, and a channel that is legitimately in both the recent group and the full list
+      // ended up beside itself, looking like a duplicate. YouTube already sorts the part that
+      // wants sorting.
       r.contents.tvBrowseRenderer.content.tvSecondaryNavRenderer.sections.forEach((entry) => {
         const section = entry.tvSecondaryNavSectionRenderer;
         if (!section || !section.tabs) return;
-
-        if (configRead('sortSubscriptionsByAlphabet')) section.tabs.sort(selectedFirstThenByTitle);
 
         section.tabs.forEach(dressTab);
       });

--- a/mods/feed/adblock.js
+++ b/mods/feed/adblock.js
@@ -114,12 +114,6 @@ onResponse('ads and shelves', RESPONSE_KEYS, (r) => {
         if (content?.gridRenderer?.items) content.gridRenderer.items = walkTiles(content.gridRenderer.items, GRID);
       };
 
-      // The tabs are not one list. YouTube sends "All", then the channels with something new,
-      // then an "A-Z" divider carrying no endpoint and no content, then every channel in order.
-      // Sorting them together flattened the three into one: the divider went to its alphabetical
-      // place, and a channel that is legitimately in both the recent group and the full list
-      // ended up beside itself, looking like a duplicate. YouTube already sorts the part that
-      // wants sorting.
       r.contents.tvBrowseRenderer.content.tvSecondaryNavRenderer.sections.forEach((entry) => {
         const section = entry.tvSecondaryNavSectionRenderer;
         if (!section || !section.tabs) return;

--- a/mods/settings/settingsModel.js
+++ b/mods/settings/settingsModel.js
@@ -214,9 +214,7 @@ const GROUPS = [
       Set_('disabledSidebarContents', 'Sections',
         'Which entries the sidebar offers', CONTROLS, SIDEBAR, true),
       Switch('disableChannelsOnSidebar', 'Channels',
-        'The channels you are subscribed to, listed under the sections', CONTROLS, false),
-      Switch('sortSubscriptionsByAlphabet', 'Sort subscriptions A\u2013Z',
-        'Alphabetical rather than the order YouTube sends', CONTROLS)
+        'The channels you are subscribed to, listed under the sections', CONTROLS, false)
     ]
   },
   {


### PR DESCRIPTION
Channels appeared twice in the subscriptions list, and it was our sorting that
did it.

The tabs are not one list. YouTube sends "All", then the channels with
something new, then an "A-Z" divider, then every channel in order. The divider
is not a tab at all: its data carries title, selected, tabIdentifier and
accessibility, and no endpoint and no content, where every real channel tab
carries endpoint, content and params.

sortSubscriptionsByAlphabet sorted all three groups together as one array. The
divider went to its alphabetical place, the recent group was interleaved with
the full list, and a channel that is legitimately in both ended up beside
itself. The pair that looked duplicated shared a browseId and params, which is
what made it read as a data fault rather than a sorting one.

Read off the set: fifteen tabs with the sort on and two duplicates, thirteen
and none with it off.

So drop it. YouTube already sorts the part that wants sorting — that is what
the A-Z section is.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>